### PR TITLE
[f1] feat: show current pr in stack

### DIFF
--- a/src/persist.rs
+++ b/src/persist.rs
@@ -27,13 +27,21 @@ fn safe_replace(body: &str, table: &str) -> String {
     }
 }
 
+fn remove_title_prefixes(row: String) -> String {
+    // TODO: Make this configurable
+    let regex = Regex::new(r"\[[^\]]+\]\s*").unwrap();
+    regex.replace_all(&row, "").into_owned()
+}
+
 pub async fn persist(
     prs: &FlatDep,
     table: &str,
     c: &Credentials,
 ) -> Result<(), Box<dyn Error>> {
     let futures = prs.iter().map(|(pr, _)| {
-        let description = safe_replace(pr.body(), table);
+        let body = table.replace(&pr.title()[..], &format!("👉 {}", pr.title())[..]);
+        let body = remove_title_prefixes(body);
+        let description = safe_replace(pr.body(), body.as_ref());
         pull_request::update_description(description, pr.clone(), c)
     });
 


### PR DESCRIPTION
This commit builds off of commit
eef30d7a68491c2a5df95dc101604de89ea0f80b from the gh-stack repository.
It removes PR prefixes and adds a pointer for the current PR.



<!---GHSTACKOPEN-->
### ✅ Stacked PR Chain: f1
| PR | Title | Status |  Merges Into  |
|:--:|:------|:-------|:-------------:|
|#1|~~chore: add completion status~~|![](https://img.shields.io/github/pulls/detail/state/luqven/gh-stack/1?label=Closed)|-|
|#2|👉 ~~feat: show current pr in stack~~|![](https://img.shields.io/github/pulls/detail/state/luqven/gh-stack/2?label=Closed)|#1|

<!---GHSTACKCLOSE-->

