### PR TITLE
feat!: configurable title prefixes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -319,7 +319,7 @@ dependencies = [
 
 [[package]]
 name = "gh-stack"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "clap",
  "console",
@@ -698,9 +698,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.4.0"
+version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b631f7e854af39a1739f401cf34a8a013dfe09eac4fa4dba91e9768bd28168d"
+checksum = "692fcb63b64b1758029e0a96ee63e049ce8c5948587f2f7208df04625e5f6b56"
 
 [[package]]
 name = "openssl"
@@ -1111,11 +1111,11 @@ dependencies = [
 
 [[package]]
 name = "thread_local"
-version = "1.0.1"
+version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d40c6d1b69745a6ec6fb1ca717914848da4b44ae29d9b3080cbee91d72a69b14"
+checksum = "8018d24e04c95ac8790716a5987d0fec4f8b27249ffa0f7d33f1369bdfb88cbd"
 dependencies = [
- "lazy_static",
+ "once_cell",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gh-stack"
-version = "0.2.0"
+version = "0.3.0"
 authors = ["Timothy Andrew <mail@timothyandrew.net>, Luis Ball <luqven@gmail.com>"]
 license = "MIT"
 repository = "https://github.com/luqven/gh-stack"


### PR DESCRIPTION
This commit adds the `--prefix` CLI option. Providing this option allows users to tell `gh-stack` their title prefixes begin and/or end with something other than `[]`. Title prefixes can only be 2 characters long. The starting prefix being the first character and the end prefix is the second character.

## Example

`gh-stack '*f1*' --prefix'*'`
`gh-stack '{f1}' --prefix'{}'`