### PR TITLE
style: apply cargo fmt formatting

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,7 +7,7 @@ Code quality and organization standards for this project.
 1. **Rust only** - No other languages in src/
 2. **Unit test each module** - Tests live in the same file with `#[cfg(test)]`
 3. **Conventional commits** - Commit when a reasonable amount of work is done
-4. **Run tests before committing** - `cargo test`
+4. **Run checks before committing** - `cargo fmt && cargo clippy && cargo test`
 5. **Keep functions focused** - Prefer 2-4 arguments, pass primitives directly
 6. **Short variable names** - Prefer concise, readable names
 

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -77,7 +77,10 @@ mod tests {
 
         let mock = server
             .mock("GET", "/search/issues")
-            .match_query(mockito::Matcher::UrlEncoded("q".into(), "TEST-123 in:title".into()))
+            .match_query(mockito::Matcher::UrlEncoded(
+                "q".into(),
+                "TEST-123 in:title".into(),
+            ))
             .with_status(200)
             .with_header("content-type", "application/json")
             .with_body(r#"{"items": []}"#)

--- a/src/api/search.rs
+++ b/src/api/search.rs
@@ -76,7 +76,6 @@ pub async fn fetch_matching_pull_requests_from_repository(
     repository: &str,
     credentials: &Credentials,
 ) -> Result<Vec<PullRequest>, Box<dyn Error>> {
-
     let client = reqwest::Client::new();
 
     let request = api::base_request(

--- a/src/graph.rs
+++ b/src/graph.rs
@@ -125,17 +125,23 @@ mod tests {
         assert_eq!(flat.len(), 3);
 
         // First PR should have no parent (base is main, not in stack)
-        assert!(flat.iter().any(|(pr, parent)| pr.number() == 1 && parent.is_none()));
+        assert!(flat
+            .iter()
+            .any(|(pr, parent)| pr.number() == 1 && parent.is_none()));
 
         // Second PR should have first as parent
-        assert!(flat
-            .iter()
-            .any(|(pr, parent)| pr.number() == 2 && parent.as_ref().map(|p| p.number()) == Some(1)));
+        assert!(
+            flat.iter()
+                .any(|(pr, parent)| pr.number() == 2
+                    && parent.as_ref().map(|p| p.number()) == Some(1))
+        );
 
         // Third PR should have second as parent
-        assert!(flat
-            .iter()
-            .any(|(pr, parent)| pr.number() == 3 && parent.as_ref().map(|p| p.number()) == Some(2)));
+        assert!(
+            flat.iter()
+                .any(|(pr, parent)| pr.number() == 3
+                    && parent.as_ref().map(|p| p.number()) == Some(2))
+        );
     }
 
     #[test]

--- a/src/markdown.rs
+++ b/src/markdown.rs
@@ -147,7 +147,15 @@ mod tests {
 
     #[test]
     fn test_build_table_single_pr() {
-        let pr = make_pr(1, "feature-1", "main", "Add new feature", PullRequestStatus::Open, false, None);
+        let pr = make_pr(
+            1,
+            "feature-1",
+            "main",
+            "Add new feature",
+            PullRequestStatus::Open,
+            false,
+            None,
+        );
         let deps: FlatDep = vec![(pr, None)];
 
         let table = build_table(&deps, "JIRA-123", None, "user/repo");
@@ -156,9 +164,33 @@ mod tests {
 
     #[test]
     fn test_build_table_linear_stack() {
-        let pr1 = make_pr(1, "feature-1", "main", "Base feature", PullRequestStatus::Open, false, None);
-        let pr2 = make_pr(2, "feature-2", "feature-1", "Second feature", PullRequestStatus::Open, false, None);
-        let pr3 = make_pr(3, "feature-3", "feature-2", "Third feature", PullRequestStatus::Open, false, None);
+        let pr1 = make_pr(
+            1,
+            "feature-1",
+            "main",
+            "Base feature",
+            PullRequestStatus::Open,
+            false,
+            None,
+        );
+        let pr2 = make_pr(
+            2,
+            "feature-2",
+            "feature-1",
+            "Second feature",
+            PullRequestStatus::Open,
+            false,
+            None,
+        );
+        let pr3 = make_pr(
+            3,
+            "feature-3",
+            "feature-2",
+            "Third feature",
+            PullRequestStatus::Open,
+            false,
+            None,
+        );
 
         let deps: FlatDep = vec![
             (pr1.clone(), None),
@@ -172,7 +204,15 @@ mod tests {
 
     #[test]
     fn test_build_table_with_draft_pr() {
-        let pr = make_pr(1, "wip-feature", "main", "Work in progress", PullRequestStatus::Open, true, None);
+        let pr = make_pr(
+            1,
+            "wip-feature",
+            "main",
+            "Work in progress",
+            PullRequestStatus::Open,
+            true,
+            None,
+        );
         let deps: FlatDep = vec![(pr, None)];
 
         let table = build_table(&deps, "DRAFT-TEST", None, "user/repo");
@@ -181,7 +221,15 @@ mod tests {
 
     #[test]
     fn test_build_table_with_closed_pr() {
-        let pr = make_pr(1, "old-feature", "main", "Completed feature", PullRequestStatus::Closed, false, None);
+        let pr = make_pr(
+            1,
+            "old-feature",
+            "main",
+            "Completed feature",
+            PullRequestStatus::Closed,
+            false,
+            None,
+        );
         let deps: FlatDep = vec![(pr, None)];
 
         let table = build_table(&deps, "CLOSED-TEST", None, "user/repo");
@@ -207,13 +255,26 @@ mod tests {
 
     #[test]
     fn test_build_table_all_closed_shows_checkmark() {
-        let pr1 = make_pr(1, "feature-1", "main", "First", PullRequestStatus::Closed, false, None);
-        let pr2 = make_pr(2, "feature-2", "feature-1", "Second", PullRequestStatus::Closed, false, None);
+        let pr1 = make_pr(
+            1,
+            "feature-1",
+            "main",
+            "First",
+            PullRequestStatus::Closed,
+            false,
+            None,
+        );
+        let pr2 = make_pr(
+            2,
+            "feature-2",
+            "feature-1",
+            "Second",
+            PullRequestStatus::Closed,
+            false,
+            None,
+        );
 
-        let deps: FlatDep = vec![
-            (pr1.clone(), None),
-            (pr2.clone(), Some(pr1.clone())),
-        ];
+        let deps: FlatDep = vec![(pr1.clone(), None), (pr2.clone(), Some(pr1.clone()))];
 
         let table = build_table(&deps, "COMPLETE-STACK", None, "user/repo");
         insta::assert_snapshot!(table);
@@ -230,8 +291,24 @@ mod tests {
             false,
             Some("2024-01-15T10:00:00Z".to_string()),
         );
-        let pr2 = make_pr(2, "feature-2", "feature-1", "Open follow-up", PullRequestStatus::Open, false, None);
-        let pr3 = make_pr(3, "feature-3", "feature-2", "Draft WIP", PullRequestStatus::Open, true, None);
+        let pr2 = make_pr(
+            2,
+            "feature-2",
+            "feature-1",
+            "Open follow-up",
+            PullRequestStatus::Open,
+            false,
+            None,
+        );
+        let pr3 = make_pr(
+            3,
+            "feature-3",
+            "feature-2",
+            "Draft WIP",
+            PullRequestStatus::Open,
+            true,
+            None,
+        );
 
         let deps: FlatDep = vec![
             (pr1.clone(), None),

--- a/src/util.rs
+++ b/src/util.rs
@@ -3,10 +3,7 @@ use dialoguer::Input;
 pub fn loop_until_confirm(prompt: &str) {
     let prompt = format!("{} Type 'yes' to continue", prompt);
     loop {
-        let result: String = Input::new()
-            .with_prompt(&prompt)
-            .interact_text()
-            .unwrap();
+        let result: String = Input::new().with_prompt(&prompt).interact_text().unwrap();
         match &result[..] {
             "yes" => return,
             _ => continue,


### PR DESCRIPTION
Fix CI failure by applying `cargo fmt` formatting to all source files.