### PR TITLE
[PRIVATE-REPO] feat: add use_badges parameter to build_table

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -219,8 +219,13 @@ async fn main() -> Result<(), Box<dyn Error>> {
                 build_pr_stack_for_repo(&identifier, repository, &credentials, get_excluded(m))
                     .await?;
 
-            let table =
-                markdown::build_table(&stack, &identifier, m.value_of("prelude"), repository);
+            let table = markdown::build_table(
+                &stack,
+                &identifier,
+                m.value_of("prelude"),
+                repository,
+                false,
+            );
 
             for (pr, _) in stack.iter() {
                 println!("{}: {}", pr.number(), pr.title());

--- a/src/snapshots/gh_stack__markdown__tests__build_table_all_closed_shows_checkmark.snap
+++ b/src/snapshots/gh_stack__markdown__tests__build_table_all_closed_shows_checkmark.snap
@@ -3,7 +3,7 @@ source: src/markdown.rs
 expression: table
 ---
 ### ✅ Stacked PR Chain: COMPLETE-STACK
-| PR | Title | Status |  Merges Into  |
-|:--:|:------|:-------|:-------------:|
-|#1|~~First~~|![](https://img.shields.io/github/pulls/detail/state/user/repo/1?label=Closed)|-|
-|#2|~~Second~~|![](https://img.shields.io/github/pulls/detail/state/user/repo/2?label=Closed)|#1|
+| PR | Title | Merges Into |
+|:--:|:------|:-----------:|
+|#1|~~First~~|-|
+|#2|~~Second~~|#1|

--- a/src/snapshots/gh_stack__markdown__tests__build_table_linear_stack.snap
+++ b/src/snapshots/gh_stack__markdown__tests__build_table_linear_stack.snap
@@ -3,8 +3,8 @@ source: src/markdown.rs
 expression: table
 ---
 ### Stacked PR Chain: STACK-456
-| PR | Title | Status |  Merges Into  |
-|:--:|:------|:-------|:-------------:|
-|#1|Base feature|![](https://img.shields.io/github/pulls/detail/state/org/project/1?label=Pending)|-|
-|#2|Second feature|![](https://img.shields.io/github/pulls/detail/state/org/project/2?label=Pending)|#1|
-|#3|Third feature|![](https://img.shields.io/github/pulls/detail/state/org/project/3?label=Pending)|#2|
+| PR | Title | Merges Into |
+|:--:|:------|:-----------:|
+|#1|Base feature|-|
+|#2|Second feature|#1|
+|#3|Third feature|#2|

--- a/src/snapshots/gh_stack__markdown__tests__build_table_mixed_states.snap
+++ b/src/snapshots/gh_stack__markdown__tests__build_table_mixed_states.snap
@@ -3,8 +3,8 @@ source: src/markdown.rs
 expression: table
 ---
 ### Stacked PR Chain: MIXED-STACK
-| PR | Title | Status |  Merges Into  |
-|:--:|:------|:-------|:-------------:|
-|#1|~~Merged base~~|![](https://img.shields.io/github/pulls/detail/state/org/repo/1?label=%20)|-|
-|#2|Open follow-up|![](https://img.shields.io/github/pulls/detail/state/org/repo/2?label=Pending)|#1|
-|#3|*(Draft) Draft WIP*|![](https://img.shields.io/github/pulls/detail/state/org/repo/3?label=Pending)|#2|
+| PR | Title | Merges Into |
+|:--:|:------|:-----------:|
+|#1|~~Merged base~~|-|
+|#2|Open follow-up|#1|
+|#3|*(Draft) Draft WIP*|#2|

--- a/src/snapshots/gh_stack__markdown__tests__build_table_single_pr.snap
+++ b/src/snapshots/gh_stack__markdown__tests__build_table_single_pr.snap
@@ -3,6 +3,6 @@ source: src/markdown.rs
 expression: table
 ---
 ### Stacked PR Chain: JIRA-123
-| PR | Title | Status |  Merges Into  |
-|:--:|:------|:-------|:-------------:|
-|#1|Add new feature|![](https://img.shields.io/github/pulls/detail/state/user/repo/1?label=Pending)|-|
+| PR | Title | Merges Into |
+|:--:|:------|:-----------:|
+|#1|Add new feature|-|

--- a/src/snapshots/gh_stack__markdown__tests__build_table_with_badges.snap
+++ b/src/snapshots/gh_stack__markdown__tests__build_table_with_badges.snap
@@ -1,0 +1,9 @@
+---
+source: src/markdown.rs
+expression: table
+---
+### Stacked PR Chain: BADGES-TEST
+| PR | Title | Status | Merges Into |
+|:--:|:------|:-------|:-----------:|
+|#1|Base feature|![](https://img.shields.io/github/pulls/detail/state/org/project/1?label=Pending)|-|
+|#2|Second feature|![](https://img.shields.io/github/pulls/detail/state/org/project/2?label=Pending)|#1|

--- a/src/snapshots/gh_stack__markdown__tests__build_table_with_badges_mixed_states.snap
+++ b/src/snapshots/gh_stack__markdown__tests__build_table_with_badges_mixed_states.snap
@@ -1,0 +1,10 @@
+---
+source: src/markdown.rs
+expression: table
+---
+### Stacked PR Chain: BADGES-MIXED
+| PR | Title | Status | Merges Into |
+|:--:|:------|:-------|:-----------:|
+|#1|~~Merged base~~|![](https://img.shields.io/github/pulls/detail/state/org/repo/1?label=%20)|-|
+|#2|Open follow-up|![](https://img.shields.io/github/pulls/detail/state/org/repo/2?label=Pending)|#1|
+|#3|*(Draft) Draft WIP*|![](https://img.shields.io/github/pulls/detail/state/org/repo/3?label=Pending)|#2|

--- a/src/snapshots/gh_stack__markdown__tests__build_table_with_closed_pr.snap
+++ b/src/snapshots/gh_stack__markdown__tests__build_table_with_closed_pr.snap
@@ -3,6 +3,6 @@ source: src/markdown.rs
 expression: table
 ---
 ### ✅ Stacked PR Chain: CLOSED-TEST
-| PR | Title | Status |  Merges Into  |
-|:--:|:------|:-------|:-------------:|
-|#1|~~Completed feature~~|![](https://img.shields.io/github/pulls/detail/state/user/repo/1?label=Closed)|-|
+| PR | Title | Merges Into |
+|:--:|:------|:-----------:|
+|#1|~~Completed feature~~|-|

--- a/src/snapshots/gh_stack__markdown__tests__build_table_with_draft_pr.snap
+++ b/src/snapshots/gh_stack__markdown__tests__build_table_with_draft_pr.snap
@@ -3,6 +3,6 @@ source: src/markdown.rs
 expression: table
 ---
 ### Stacked PR Chain: DRAFT-TEST
-| PR | Title | Status |  Merges Into  |
-|:--:|:------|:-------|:-------------:|
-|#1|*(Draft) Work in progress*|![](https://img.shields.io/github/pulls/detail/state/user/repo/1?label=Pending)|-|
+| PR | Title | Merges Into |
+|:--:|:------|:-----------:|
+|#1|*(Draft) Work in progress*|-|

--- a/src/snapshots/gh_stack__markdown__tests__build_table_with_merged_pr.snap
+++ b/src/snapshots/gh_stack__markdown__tests__build_table_with_merged_pr.snap
@@ -3,6 +3,6 @@ source: src/markdown.rs
 expression: table
 ---
 ### ✅ Stacked PR Chain: MERGED-TEST
-| PR | Title | Status |  Merges Into  |
-|:--:|:------|:-------|:-------------:|
-|#1|~~Merged feature~~|![](https://img.shields.io/github/pulls/detail/state/user/repo/1?label=%20)|-|
+| PR | Title | Merges Into |
+|:--:|:------|:-----------:|
+|#1|~~Merged feature~~|-|


### PR DESCRIPTION
## Summary

- Add `use_badges` parameter to `build_table` function
- Default (`false`) generates 3-column table without shields.io badges
- When `true`, generates 4-column table with shields.io status badges
- Update existing tests to use new default (no badges)
- Add new tests for badges mode

This is part 1/3 of the private repo support feature.

<!---GHSTACKOPEN-->
### Stacked PR Chain: PRIVATE-REPO
| PR | Title | Status |  Merges Into  |
|:--:|:------|:-------|:-------------:|
|#24|👉feat: add use_badges parameter to build_table|![](https://img.shields.io/github/pulls/detail/state/luqven/gh-stack/24?label=Pending)|-|
|#25|feat: add --badges flag to annotate command|![](https://img.shields.io/github/pulls/detail/state/luqven/gh-stack/25?label=Pending)|#24|
|#26|docs: update README for --badges flag|![](https://img.shields.io/github/pulls/detail/state/luqven/gh-stack/26?label=Pending)|#25|
|#27|docs: add stacked PR workflow to AGENTS.md|![](https://img.shields.io/github/pulls/detail/state/luqven/gh-stack/27?label=Pending)|#26|
<!---GHSTACKCLOSE-->

