### PR TITLE
[PRIVATE-REPO] feat: add --badges flag to annotate command

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -41,6 +41,11 @@ fn clap<'a, 'b>() -> App<'a, 'b> {
         .takes_value(true)
         .help("PR title prefix identifier to remove from the title");
 
+    let badges = Arg::with_name("badges")
+        .long("badges")
+        .takes_value(false)
+        .help("Use shields.io badges for PR status (requires public repo visibility)");
+
     let annotate = SubCommand::with_name("annotate")
         .about("Annotate the descriptions of all PRs in a stack with metadata about all PRs in the stack")
         .setting(AppSettings::ArgRequiredElseHelp)
@@ -49,6 +54,7 @@ fn clap<'a, 'b>() -> App<'a, 'b> {
         .arg(repository.clone())
         .arg(ci.clone())
         .arg(prefix.clone())
+        .arg(badges.clone())
         .arg(Arg::with_name("prelude")
                 .long("prelude")
                 .short("p")
@@ -219,12 +225,13 @@ async fn main() -> Result<(), Box<dyn Error>> {
                 build_pr_stack_for_repo(&identifier, repository, &credentials, get_excluded(m))
                     .await?;
 
+            let use_badges = m.is_present("badges");
             let table = markdown::build_table(
                 &stack,
                 &identifier,
                 m.value_of("prelude"),
                 repository,
-                false,
+                use_badges,
             );
 
             for (pr, _) in stack.iter() {


### PR DESCRIPTION
## Summary

- Add `--badges` CLI flag to enable shields.io status badges
- Default behavior now generates simpler table without badges
- Works with private repositories by default

This is part 2/3 of the private repo support feature.

<!---GHSTACKOPEN-->
### Stacked PR Chain: PRIVATE-REPO
| PR | Title | Status |  Merges Into  |
|:--:|:------|:-------|:-------------:|
|#24|feat: add use_badges parameter to build_table|![](https://img.shields.io/github/pulls/detail/state/luqven/gh-stack/24?label=Pending)|-|
|#25|👉feat: add --badges flag to annotate command|![](https://img.shields.io/github/pulls/detail/state/luqven/gh-stack/25?label=Pending)|#24|
|#26|docs: update README for --badges flag|![](https://img.shields.io/github/pulls/detail/state/luqven/gh-stack/26?label=Pending)|#25|
|#27|docs: add stacked PR workflow to AGENTS.md|![](https://img.shields.io/github/pulls/detail/state/luqven/gh-stack/27?label=Pending)|#26|
<!---GHSTACKCLOSE-->

