### PR TITLE
feat: add land command for merging stacked PRs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -436,6 +436,7 @@ dependencies = [
  "reqwest",
  "serde",
  "serde_json",
+ "serial_test",
  "tokio",
  "tokio-test",
 ]
@@ -1286,6 +1287,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "71d301d4193d031abdd79ff7e3dd721168a9572ef3fe51a1517aba235bd8f86e"
 
 [[package]]
+name = "scc"
+version = "2.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46e6f046b7fef48e2660c57ed794263155d713de679057f2d0c169bfc6e756cc"
+dependencies = [
+ "sdd",
+]
+
+[[package]]
 name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1300,6 +1310,12 @@ dependencies = [
  "ring",
  "untrusted",
 ]
+
+[[package]]
+name = "sdd"
+version = "3.0.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "490dcfcbfef26be6800d11870ff2df8774fa6e86d047e3e8c8a76b25655e41ca"
 
 [[package]]
 name = "serde"
@@ -1352,6 +1368,31 @@ dependencies = [
  "itoa 1.0.17",
  "ryu",
  "serde",
+]
+
+[[package]]
+name = "serial_test"
+version = "3.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b258109f244e1d6891bf1053a55d63a5cd4f8f4c30cf9a1280989f80e7a1fa9"
+dependencies = [
+ "futures",
+ "log",
+ "once_cell",
+ "parking_lot",
+ "scc",
+ "serial_test_derive",
+]
+
+[[package]]
+name = "serial_test_derive"
+version = "3.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d69265a08751de7844521fd15003ae0a888e035773ba05695c5c759a6f89eef"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.111",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,4 +30,5 @@ chrono = { version = "0.4", features = ["serde"] }
 [dev-dependencies]
 insta = "1.39"
 mockito = "1.4"
+serial_test = "3.1"
 tokio-test = "0.4"

--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ With this graph built up, the tool can:
 - Add a markdown table to the PR description (idempotently) of each PR in the stack describing _all_ PRs in the stack.
 - Log a simple list of all PRs in the stack (+ dependencies) to stdout.
 - Automatically update the stack + push after making local changes.
+- **Land an entire stack** by squash-merging the topmost approved PR and closing the rest.
 
 ---
 
@@ -66,7 +67,8 @@ cargo install --force --path .
 # Set the environment variable for the Github API token
 $ export GHSTACK_OAUTH_TOKEN='<personal access token>'
 
-# Set the environment variable for the repository owner/name
+# Optional: The repository is auto-detected from your git remote.
+# You can override it with an environment variable or the -r flag:
 $ export GHSTACK_TARGET_REPOSITORY='<github repository name>'
 
 # You can also set these in a `.gh-stack.env` file in the project root.
@@ -84,17 +86,18 @@ FLAGS:
 SUBCOMMANDS:
     annotate      Annotate the descriptions of all PRs in a stack with metadata about all PRs in the stack
     autorebase    Rebuild a stack based on changes to local branches and mirror these changes up to the remote
+    land          Land a stack by squash-merging the topmost approved PR and closing the rest
     log           Print a list of all pull requests in a stack to STDOUT
     rebase        Print a bash script to STDOUT that can rebase/update the stack (with a little help)
 
-# Print a description of the stack to stdout. for a specific repository.
+# Print a description of the stack to stdout (auto-detects repository from git remote)
 $ gh-stack log 'stack-identifier'
 
-# # Idempotently add a markdown table summarizing the stack
-# to the description of each PR in the stack for a specific repository.
+# Idempotently add a markdown table summarizing the stack
+# to the description of each PR in the stack
 $ gh-stack annotate 'stack-identifier'
 
-# Same as above, but for the specified repository.
+# Override auto-detected repository with -r flag
 $ gh-stack annotate 'stack-identifier' -r '<some/repo>'
 
 # Same as above, but with a custom title prefix.
@@ -115,6 +118,18 @@ $ gh-stack autorebase 'stack-identifier' -C /path/to/repo
 
 # Same as above, but skips confirmation step.
 $ gh-stack autorebase 'stack-identifier' -C /path/to/repo --ci
+
+# Land the entire stack (squash-merges topmost approved PR, closes the rest)
+$ gh-stack land 'stack-identifier'
+
+# Preview what would happen without making changes
+$ gh-stack land 'stack-identifier' --dry-run
+
+# Skip approval requirement check
+$ gh-stack land 'stack-identifier' --no-approval
+
+# Only land the bottom N PRs in the stack
+$ gh-stack land 'stack-identifier' --count 2
 
 # Emit a bash script that can update a stack in the case of conflicts.
 # WARNING: This script could potentially cause destructive behavior.

--- a/src/api/land.rs
+++ b/src/api/land.rs
@@ -1,0 +1,336 @@
+//! GitHub API methods for landing PRs
+//!
+//! This module provides functions to:
+//! - Update a PR's base branch
+//! - Merge a PR using squash strategy
+//! - Close a PR with a comment
+
+use reqwest::Client;
+use serde::{Deserialize, Serialize};
+use std::error::Error;
+use std::time::Duration;
+
+use crate::Credentials;
+
+/// Request body for updating a PR's base branch
+#[derive(Serialize, Debug)]
+struct UpdatePrBaseRequest<'a> {
+    base: &'a str,
+}
+
+/// Request body for merging a PR
+#[derive(Serialize, Debug)]
+struct MergePrRequest<'a> {
+    merge_method: &'a str,
+}
+
+/// Request body for closing a PR
+#[derive(Serialize, Debug)]
+struct ClosePrRequest {
+    state: &'static str,
+}
+
+/// Request body for adding a comment
+#[derive(Serialize, Debug)]
+struct AddCommentRequest<'a> {
+    body: &'a str,
+}
+
+/// Response from merge endpoint
+#[derive(Deserialize, Debug)]
+#[allow(dead_code)]
+struct MergeResponse {
+    sha: String,
+    merged: bool,
+    message: String,
+}
+
+/// Response with HTML URL
+#[derive(Deserialize, Debug)]
+struct PrResponse {
+    html_url: String,
+}
+
+fn build_request(client: &Client, credentials: &Credentials, url: &str) -> reqwest::RequestBuilder {
+    client
+        .patch(url)
+        .timeout(Duration::from_secs(30))
+        .header("Authorization", format!("token {}", credentials.token))
+        .header("User-Agent", "luqven/gh-stack")
+        .header("Accept", "application/vnd.github.v3+json")
+}
+
+fn build_put_request(
+    client: &Client,
+    credentials: &Credentials,
+    url: &str,
+) -> reqwest::RequestBuilder {
+    client
+        .put(url)
+        .timeout(Duration::from_secs(30))
+        .header("Authorization", format!("token {}", credentials.token))
+        .header("User-Agent", "luqven/gh-stack")
+        .header("Accept", "application/vnd.github.v3+json")
+}
+
+fn build_post_request(
+    client: &Client,
+    credentials: &Credentials,
+    url: &str,
+) -> reqwest::RequestBuilder {
+    client
+        .post(url)
+        .timeout(Duration::from_secs(30))
+        .header("Authorization", format!("token {}", credentials.token))
+        .header("User-Agent", "luqven/gh-stack")
+        .header("Accept", "application/vnd.github.v3+json")
+}
+
+/// Update a PR's base branch
+///
+/// # Arguments
+/// * `pr_number` - The PR number
+/// * `new_base` - The new base branch name (e.g., "main")
+/// * `repository` - Repository in "owner/repo" format
+/// * `credentials` - GitHub credentials
+pub async fn update_pr_base(
+    pr_number: usize,
+    new_base: &str,
+    repository: &str,
+    credentials: &Credentials,
+) -> Result<(), Box<dyn Error>> {
+    let client = Client::new();
+    let url = format!(
+        "{}/repos/{}/pulls/{}",
+        super::github_api_base(),
+        repository,
+        pr_number
+    );
+
+    let body = UpdatePrBaseRequest { base: new_base };
+    let response = build_request(&client, credentials, &url)
+        .json(&body)
+        .send()
+        .await?;
+
+    if !response.status().is_success() {
+        let status = response.status();
+        let text = response.text().await.unwrap_or_default();
+        return Err(format!("Failed to update PR base ({}): {}", status, text).into());
+    }
+
+    Ok(())
+}
+
+/// Merge a PR using squash strategy
+///
+/// # Arguments
+/// * `pr_number` - The PR number
+/// * `repository` - Repository in "owner/repo" format
+/// * `credentials` - GitHub credentials
+///
+/// # Returns
+/// The HTML URL of the merged PR
+pub async fn merge_pr(
+    pr_number: usize,
+    repository: &str,
+    credentials: &Credentials,
+) -> Result<String, Box<dyn Error>> {
+    let client = Client::new();
+    let url = format!(
+        "{}/repos/{}/pulls/{}/merge",
+        super::github_api_base(),
+        repository,
+        pr_number
+    );
+
+    let body = MergePrRequest {
+        merge_method: "squash",
+    };
+    let response = build_put_request(&client, credentials, &url)
+        .json(&body)
+        .send()
+        .await?;
+
+    if !response.status().is_success() {
+        let status = response.status();
+        let text = response.text().await.unwrap_or_default();
+        return Err(format!("Failed to merge PR ({}): {}", status, text).into());
+    }
+
+    let merge_response: MergeResponse = response.json().await?;
+    if !merge_response.merged {
+        return Err(format!("PR was not merged: {}", merge_response.message).into());
+    }
+
+    // Get the PR HTML URL
+    let pr_url = format!(
+        "{}/repos/{}/pulls/{}",
+        super::github_api_base(),
+        repository,
+        pr_number
+    );
+    let pr_response = client
+        .get(&pr_url)
+        .timeout(Duration::from_secs(10))
+        .header("Authorization", format!("token {}", credentials.token))
+        .header("User-Agent", "luqven/gh-stack")
+        .send()
+        .await?;
+
+    let pr_data: PrResponse = pr_response.json().await?;
+    Ok(pr_data.html_url)
+}
+
+/// Close a PR with a comment
+///
+/// # Arguments
+/// * `pr_number` - The PR number
+/// * `comment` - Comment to add before closing
+/// * `repository` - Repository in "owner/repo" format
+/// * `credentials` - GitHub credentials
+pub async fn close_pr_with_comment(
+    pr_number: usize,
+    comment: &str,
+    repository: &str,
+    credentials: &Credentials,
+) -> Result<(), Box<dyn Error>> {
+    let client = Client::new();
+
+    // First, add a comment
+    let comment_url = format!(
+        "{}/repos/{}/issues/{}/comments",
+        super::github_api_base(),
+        repository,
+        pr_number
+    );
+    let comment_body = AddCommentRequest { body: comment };
+    let comment_response = build_post_request(&client, credentials, &comment_url)
+        .json(&comment_body)
+        .send()
+        .await?;
+
+    if !comment_response.status().is_success() {
+        let status = comment_response.status();
+        let text = comment_response.text().await.unwrap_or_default();
+        return Err(format!("Failed to add comment ({}): {}", status, text).into());
+    }
+
+    // Then close the PR
+    let close_url = format!(
+        "{}/repos/{}/pulls/{}",
+        super::github_api_base(),
+        repository,
+        pr_number
+    );
+    let close_body = ClosePrRequest { state: "closed" };
+    let close_response = build_request(&client, credentials, &close_url)
+        .json(&close_body)
+        .send()
+        .await?;
+
+    if !close_response.status().is_success() {
+        let status = close_response.status();
+        let text = close_response.text().await.unwrap_or_default();
+        return Err(format!("Failed to close PR ({}): {}", status, text).into());
+    }
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use mockito::Server;
+    use serial_test::serial;
+
+    #[tokio::test]
+    #[serial]
+    async fn test_update_pr_base() {
+        let mut server = Server::new_async().await;
+
+        let mock = server
+            .mock("PATCH", "/repos/owner/repo/pulls/123")
+            .match_body(mockito::Matcher::Json(serde_json::json!({"base": "main"})))
+            .with_status(200)
+            .with_body("{}")
+            .create_async()
+            .await;
+
+        std::env::set_var("GITHUB_API_BASE", server.url());
+
+        let creds = Credentials::new("test-token");
+        let result = update_pr_base(123, "main", "owner/repo", &creds).await;
+
+        assert!(result.is_ok());
+        mock.assert_async().await;
+    }
+
+    #[tokio::test]
+    #[serial]
+    async fn test_merge_pr() {
+        let mut server = Server::new_async().await;
+
+        let merge_mock = server
+            .mock("PUT", "/repos/owner/repo/pulls/123/merge")
+            .match_body(mockito::Matcher::Json(
+                serde_json::json!({"merge_method": "squash"}),
+            ))
+            .with_status(200)
+            .with_body(r#"{"sha": "abc123", "merged": true, "message": "Pull Request successfully merged"}"#)
+            .create_async()
+            .await;
+
+        let pr_mock = server
+            .mock("GET", "/repos/owner/repo/pulls/123")
+            .with_status(200)
+            .with_body(r#"{"html_url": "https://github.com/owner/repo/pull/123"}"#)
+            .create_async()
+            .await;
+
+        std::env::set_var("GITHUB_API_BASE", server.url());
+
+        let creds = Credentials::new("test-token");
+        let result = merge_pr(123, "owner/repo", &creds).await;
+
+        assert!(result.is_ok());
+        assert_eq!(result.unwrap(), "https://github.com/owner/repo/pull/123");
+        merge_mock.assert_async().await;
+        pr_mock.assert_async().await;
+    }
+
+    #[tokio::test]
+    #[serial]
+    async fn test_close_pr_with_comment() {
+        let mut server = Server::new_async().await;
+
+        let comment_mock = server
+            .mock("POST", "/repos/owner/repo/issues/123/comments")
+            .match_body(mockito::Matcher::Json(
+                serde_json::json!({"body": "Landed via #456"}),
+            ))
+            .with_status(201)
+            .with_body("{}")
+            .create_async()
+            .await;
+
+        let close_mock = server
+            .mock("PATCH", "/repos/owner/repo/pulls/123")
+            .match_body(mockito::Matcher::Json(
+                serde_json::json!({"state": "closed"}),
+            ))
+            .with_status(200)
+            .with_body("{}")
+            .create_async()
+            .await;
+
+        std::env::set_var("GITHUB_API_BASE", server.url());
+
+        let creds = Credentials::new("test-token");
+        let result = close_pr_with_comment(123, "Landed via #456", "owner/repo", &creds).await;
+
+        assert!(result.is_ok());
+        comment_mock.assert_async().await;
+        close_mock.assert_async().await;
+    }
+}

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -2,6 +2,7 @@ use crate::Credentials;
 use reqwest::{Client, RequestBuilder};
 use std::time::Duration;
 
+pub mod land;
 pub mod pull_request;
 pub mod search;
 

--- a/src/api/pull_request.rs
+++ b/src/api/pull_request.rs
@@ -25,6 +25,15 @@ pub struct PullRequestReview {
 }
 
 impl PullRequestReview {
+    /// Create a new PullRequestReview for testing purposes
+    #[cfg(test)]
+    pub fn new_for_test(state: PullRequestReviewState) -> Self {
+        PullRequestReview {
+            state,
+            body: String::new(),
+        }
+    }
+
     pub fn is_approved(&self) -> bool {
         self.state == PullRequestReviewState::APPROVED
     }

--- a/src/land.rs
+++ b/src/land.rs
@@ -1,0 +1,554 @@
+//! Landing logic for stacked PRs
+//!
+//! This module implements the spr/Graphite optimization pattern:
+//! 1. Find the topmost PR where all PRs below it are approved
+//! 2. Update that PR's base to the target branch
+//! 3. Squash-merge that single PR (contains all commits from the stack)
+//! 4. Close all PRs below it with a comment linking to the merged PR
+
+use std::error::Error;
+use std::fmt;
+use std::rc::Rc;
+
+use crate::api::PullRequest;
+use crate::graph::FlatDep;
+use crate::Credentials;
+
+/// Represents a plan for landing a stack of PRs
+#[derive(Debug)]
+pub struct LandPlan {
+    /// The PR that will be merged (topmost mergeable PR)
+    pub top_pr: Rc<PullRequest>,
+    /// PRs below top that will be closed after merge
+    pub prs_to_close: Vec<Rc<PullRequest>>,
+    /// Target branch to merge into (e.g., "main" or "master")
+    pub target_branch: String,
+    /// Repository in "owner/repo" format
+    pub repository: String,
+}
+
+/// Result of a successful landing operation
+#[derive(Debug)]
+pub struct LandResult {
+    /// The PR that was merged
+    pub merged_pr: Rc<PullRequest>,
+    /// PRs that were closed
+    pub closed_prs: Vec<Rc<PullRequest>>,
+    /// URL of the merged PR
+    pub merge_url: String,
+}
+
+/// Errors that can occur during landing
+#[derive(Debug)]
+pub enum LandError {
+    /// No PRs found in the stack
+    NoPRsInStack,
+    /// No PRs are in a mergeable state
+    NoPRsMergeable { reason: String },
+    /// A PR is in draft state and blocks landing
+    DraftBlocking { pr_number: usize },
+    /// A PR requires approval
+    ApprovalRequired { pr_number: usize },
+    /// API call failed
+    ApiError { message: String },
+}
+
+impl fmt::Display for LandError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            LandError::NoPRsInStack => write!(f, "No PRs found in the stack"),
+            LandError::NoPRsMergeable { reason } => {
+                write!(f, "No PRs are mergeable: {}", reason)
+            }
+            LandError::DraftBlocking { pr_number } => {
+                write!(
+                    f,
+                    "PR #{} is a draft and blocks landing of PRs above it",
+                    pr_number
+                )
+            }
+            LandError::ApprovalRequired { pr_number } => {
+                write!(f, "PR #{} requires approval", pr_number)
+            }
+            LandError::ApiError { message } => write!(f, "API error: {}", message),
+        }
+    }
+}
+
+impl Error for LandError {}
+
+/// Options for creating a land plan
+pub struct LandOptions {
+    /// Whether to require approval on all PRs
+    pub require_approval: bool,
+    /// Maximum number of PRs to land (None = all mergeable)
+    pub max_count: Option<usize>,
+}
+
+impl Default for LandOptions {
+    fn default() -> Self {
+        LandOptions {
+            require_approval: true,
+            max_count: None,
+        }
+    }
+}
+
+/// Order the stack from base to top (PRs targeting main/master first)
+fn order_stack_base_to_top(stack: &FlatDep) -> Vec<Rc<PullRequest>> {
+    // Find root PRs (those with no parent in the stack)
+    let mut ordered = Vec::new();
+    let mut remaining: Vec<_> = stack.iter().collect();
+
+    // Start with PRs that have no parent (base of stack)
+    while !remaining.is_empty() {
+        let mut found_any = false;
+
+        remaining.retain(|(pr, parent)| {
+            let dominated_by_parent = parent
+                .as_ref()
+                .map(|p| {
+                    // Check if parent is already in ordered list
+                    ordered
+                        .iter()
+                        .any(|o: &Rc<PullRequest>| o.number() == p.number())
+                })
+                .unwrap_or(true); // No parent means it's a root
+
+            if dominated_by_parent {
+                ordered.push(pr.clone());
+                found_any = true;
+                false // Remove from remaining
+            } else {
+                true // Keep in remaining
+            }
+        });
+
+        // Safety: prevent infinite loop if graph is malformed
+        if !found_any && !remaining.is_empty() {
+            // Add remaining PRs in any order
+            for (pr, _) in remaining.drain(..) {
+                ordered.push(pr.clone());
+            }
+        }
+    }
+
+    ordered
+}
+
+/// Check if a PR is approved (has at least one approval review)
+fn is_pr_approved(pr: &PullRequest) -> bool {
+    use crate::api::PullRequestReviewState;
+    matches!(
+        pr.review_state(),
+        PullRequestReviewState::APPROVED | PullRequestReviewState::MERGED
+    )
+}
+
+/// Analyze the stack and create a landing plan
+pub fn create_land_plan(
+    stack: &FlatDep,
+    repository: &str,
+    options: &LandOptions,
+) -> Result<LandPlan, LandError> {
+    if stack.is_empty() {
+        return Err(LandError::NoPRsInStack);
+    }
+
+    // Order from base to top
+    let ordered = order_stack_base_to_top(stack);
+
+    // Filter to only open PRs
+    let open_prs: Vec<_> = ordered
+        .into_iter()
+        .filter(|pr| !pr.is_merged() && pr.state() == &crate::api::PullRequestStatus::Open)
+        .collect();
+
+    if open_prs.is_empty() {
+        return Err(LandError::NoPRsMergeable {
+            reason: "All PRs are already merged or closed".to_string(),
+        });
+    }
+
+    // Find the target branch (base of the first PR)
+    let target_branch = stack
+        .iter()
+        .find(|(_, parent)| parent.is_none())
+        .map(|(pr, _)| pr.base().to_string())
+        .unwrap_or_else(|| "main".to_string());
+
+    // Find mergeable PRs (stopping at first draft or unapproved PR)
+    let mut mergeable: Vec<Rc<PullRequest>> = Vec::new();
+
+    for pr in open_prs.iter() {
+        // Check for draft PRs
+        if pr.is_draft() {
+            if mergeable.is_empty() {
+                return Err(LandError::DraftBlocking {
+                    pr_number: pr.number(),
+                });
+            }
+            break; // Draft blocks PRs above it
+        }
+
+        // Check for approval if required
+        if options.require_approval && !is_pr_approved(pr) {
+            if mergeable.is_empty() {
+                return Err(LandError::ApprovalRequired {
+                    pr_number: pr.number(),
+                });
+            }
+            break; // Unapproved PR blocks PRs above it
+        }
+
+        mergeable.push(pr.clone());
+
+        // Respect max_count
+        if let Some(max) = options.max_count {
+            if mergeable.len() >= max {
+                break;
+            }
+        }
+    }
+
+    if mergeable.is_empty() {
+        return Err(LandError::NoPRsMergeable {
+            reason: "No PRs passed approval/draft checks".to_string(),
+        });
+    }
+
+    // Top PR = last in mergeable list (will be merged)
+    // Rest = PRs to close
+    let top_pr = mergeable.pop().unwrap();
+    let prs_to_close = mergeable;
+
+    Ok(LandPlan {
+        top_pr,
+        prs_to_close,
+        target_branch,
+        repository: repository.to_string(),
+    })
+}
+
+/// Format the dry-run output for a land plan
+pub fn format_dry_run(plan: &LandPlan, remaining_prs: &[Rc<PullRequest>]) -> String {
+    let mut output = String::new();
+
+    output.push_str("Landing Plan:\n");
+    output.push_str(&format!("  Target branch: {}\n\n", plan.target_branch));
+
+    // PRs to land
+    let total_to_land = plan.prs_to_close.len() + 1;
+    output.push_str(&format!("  PRs to land ({}):\n", total_to_land));
+
+    for pr in &plan.prs_to_close {
+        output.push_str(&format!(
+            "    [x] #{}: {} (will close)\n",
+            pr.number(),
+            pr.title()
+        ));
+    }
+    output.push_str(&format!(
+        "    [x] #{}: {} <- will merge\n",
+        plan.top_pr.number(),
+        plan.top_pr.title()
+    ));
+
+    // PRs not included
+    if !remaining_prs.is_empty() {
+        output.push_str(&format!(
+            "\n  PRs not included ({}):\n",
+            remaining_prs.len()
+        ));
+        for pr in remaining_prs {
+            let reason = if pr.is_draft() {
+                "draft"
+            } else {
+                "not approved"
+            };
+            output.push_str(&format!(
+                "    [ ] #{}: {} ({})\n",
+                pr.number(),
+                pr.title(),
+                reason
+            ));
+        }
+    }
+
+    output.push_str("\n  Actions that would be taken:\n");
+    output.push_str(&format!(
+        "    1. Update PR #{} base branch: {} -> {}\n",
+        plan.top_pr.number(),
+        plan.top_pr.base(),
+        plan.target_branch
+    ));
+    output.push_str(&format!(
+        "    2. Squash-merge PR #{} into {}\n",
+        plan.top_pr.number(),
+        plan.target_branch
+    ));
+
+    for (i, pr) in plan.prs_to_close.iter().enumerate() {
+        output.push_str(&format!(
+            "    {}. Close PR #{} with comment: \"Landed via #{}\"\n",
+            i + 3,
+            pr.number(),
+            plan.top_pr.number()
+        ));
+    }
+
+    output.push_str("\nRun without --dry-run to execute.\n");
+
+    output
+}
+
+/// Execute the landing plan
+pub async fn execute_land(
+    plan: &LandPlan,
+    credentials: &Credentials,
+) -> Result<LandResult, LandError> {
+    use crate::api::land::{close_pr_with_comment, merge_pr, update_pr_base};
+
+    // Step 1: Update top PR's base to target branch
+    println!(
+        "  Updating PR #{} base to {}...",
+        plan.top_pr.number(),
+        plan.target_branch
+    );
+    update_pr_base(
+        plan.top_pr.number(),
+        &plan.target_branch,
+        &plan.repository,
+        credentials,
+    )
+    .await
+    .map_err(|e| LandError::ApiError {
+        message: format!("Failed to update PR base: {}", e),
+    })?;
+
+    // Step 2: Merge the top PR
+    println!("  Merging PR #{}...", plan.top_pr.number());
+    let merge_url = merge_pr(plan.top_pr.number(), &plan.repository, credentials)
+        .await
+        .map_err(|e| LandError::ApiError {
+            message: format!("Failed to merge PR: {}", e),
+        })?;
+
+    // Step 3: Close all PRs below with comment
+    let comment = format!("Landed via #{}", plan.top_pr.number());
+    let mut closed_prs = Vec::new();
+
+    for pr in &plan.prs_to_close {
+        println!(
+            "  Closing PR #{} (landed via #{})...",
+            pr.number(),
+            plan.top_pr.number()
+        );
+        close_pr_with_comment(pr.number(), &comment, &plan.repository, credentials)
+            .await
+            .map_err(|e| LandError::ApiError {
+                message: format!("Failed to close PR #{}: {}", pr.number(), e),
+            })?;
+        closed_prs.push(pr.clone());
+    }
+
+    Ok(LandResult {
+        merged_pr: plan.top_pr.clone(),
+        closed_prs,
+        merge_url,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::api::{PullRequest, PullRequestStatus};
+
+    fn make_pr(
+        number: usize,
+        head: &str,
+        base: &str,
+        approved: bool,
+        draft: bool,
+    ) -> Rc<PullRequest> {
+        let reviews = if approved {
+            vec![crate::api::PullRequestReview::new_for_test(
+                crate::api::PullRequestReviewState::APPROVED,
+            )]
+        } else {
+            vec![]
+        };
+
+        Rc::new(PullRequest::new_for_test(
+            number,
+            head,
+            base,
+            &format!("PR #{}", number),
+            PullRequestStatus::Open,
+            draft,
+            None,
+            reviews,
+        ))
+    }
+
+    fn make_stack(prs: Vec<Rc<PullRequest>>) -> FlatDep {
+        let mut stack = Vec::new();
+        for (i, pr) in prs.iter().enumerate() {
+            let parent = if i > 0 {
+                Some(prs[i - 1].clone())
+            } else {
+                None
+            };
+            stack.push((pr.clone(), parent));
+        }
+        stack
+    }
+
+    #[test]
+    fn test_create_plan_empty_stack() {
+        let stack: FlatDep = vec![];
+        let options = LandOptions::default();
+        let result = create_land_plan(&stack, "owner/repo", &options);
+        assert!(matches!(result, Err(LandError::NoPRsInStack)));
+    }
+
+    #[test]
+    fn test_create_plan_single_approved_pr() {
+        let pr = make_pr(1, "feature-1", "main", true, false);
+        let stack = make_stack(vec![pr.clone()]);
+        let options = LandOptions::default();
+
+        let plan = create_land_plan(&stack, "owner/repo", &options).unwrap();
+
+        assert_eq!(plan.top_pr.number(), 1);
+        assert!(plan.prs_to_close.is_empty());
+        assert_eq!(plan.target_branch, "main");
+    }
+
+    #[test]
+    fn test_create_plan_all_approved() {
+        let prs = vec![
+            make_pr(1, "feature-1", "main", true, false),
+            make_pr(2, "feature-2", "feature-1", true, false),
+            make_pr(3, "feature-3", "feature-2", true, false),
+        ];
+        let stack = make_stack(prs);
+        let options = LandOptions::default();
+
+        let plan = create_land_plan(&stack, "owner/repo", &options).unwrap();
+
+        assert_eq!(plan.top_pr.number(), 3);
+        assert_eq!(plan.prs_to_close.len(), 2);
+        assert_eq!(plan.prs_to_close[0].number(), 1);
+        assert_eq!(plan.prs_to_close[1].number(), 2);
+    }
+
+    #[test]
+    fn test_create_plan_partial_approval() {
+        let prs = vec![
+            make_pr(1, "feature-1", "main", true, false),
+            make_pr(2, "feature-2", "feature-1", true, false),
+            make_pr(3, "feature-3", "feature-2", false, false), // Not approved
+        ];
+        let stack = make_stack(prs);
+        let options = LandOptions::default();
+
+        let plan = create_land_plan(&stack, "owner/repo", &options).unwrap();
+
+        // Should only include the first two approved PRs
+        assert_eq!(plan.top_pr.number(), 2);
+        assert_eq!(plan.prs_to_close.len(), 1);
+        assert_eq!(plan.prs_to_close[0].number(), 1);
+    }
+
+    #[test]
+    fn test_create_plan_first_pr_not_approved() {
+        let prs = vec![
+            make_pr(1, "feature-1", "main", false, false), // Not approved
+            make_pr(2, "feature-2", "feature-1", true, false),
+        ];
+        let stack = make_stack(prs);
+        let options = LandOptions::default();
+
+        let result = create_land_plan(&stack, "owner/repo", &options);
+        assert!(matches!(
+            result,
+            Err(LandError::ApprovalRequired { pr_number: 1 })
+        ));
+    }
+
+    #[test]
+    fn test_create_plan_draft_blocking() {
+        let prs = vec![
+            make_pr(1, "feature-1", "main", true, true), // Draft
+            make_pr(2, "feature-2", "feature-1", true, false),
+        ];
+        let stack = make_stack(prs);
+        let options = LandOptions::default();
+
+        let result = create_land_plan(&stack, "owner/repo", &options);
+        assert!(matches!(
+            result,
+            Err(LandError::DraftBlocking { pr_number: 1 })
+        ));
+    }
+
+    #[test]
+    fn test_create_plan_with_count() {
+        let prs = vec![
+            make_pr(1, "feature-1", "main", true, false),
+            make_pr(2, "feature-2", "feature-1", true, false),
+            make_pr(3, "feature-3", "feature-2", true, false),
+        ];
+        let stack = make_stack(prs);
+        let options = LandOptions {
+            require_approval: true,
+            max_count: Some(2),
+        };
+
+        let plan = create_land_plan(&stack, "owner/repo", &options).unwrap();
+
+        // Should only include first 2 PRs
+        assert_eq!(plan.top_pr.number(), 2);
+        assert_eq!(plan.prs_to_close.len(), 1);
+    }
+
+    #[test]
+    fn test_create_plan_no_approval_flag() {
+        let prs = vec![
+            make_pr(1, "feature-1", "main", false, false), // Not approved
+            make_pr(2, "feature-2", "feature-1", false, false), // Not approved
+        ];
+        let stack = make_stack(prs);
+        let options = LandOptions {
+            require_approval: false,
+            max_count: None,
+        };
+
+        let plan = create_land_plan(&stack, "owner/repo", &options).unwrap();
+
+        // Should include all PRs since approval not required
+        assert_eq!(plan.top_pr.number(), 2);
+        assert_eq!(plan.prs_to_close.len(), 1);
+    }
+
+    #[test]
+    fn test_order_stack_base_to_top() {
+        // Create PRs in reverse order
+        let pr3 = make_pr(3, "feature-3", "feature-2", true, false);
+        let pr1 = make_pr(1, "feature-1", "main", true, false);
+        let pr2 = make_pr(2, "feature-2", "feature-1", true, false);
+
+        let stack: FlatDep = vec![
+            (pr3.clone(), Some(pr2.clone())),
+            (pr1.clone(), None),
+            (pr2.clone(), Some(pr1.clone())),
+        ];
+
+        let ordered = order_stack_base_to_top(&stack);
+
+        assert_eq!(ordered[0].number(), 1);
+        assert_eq!(ordered[1].number(), 2);
+        assert_eq!(ordered[2].number(), 3);
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,7 @@
 pub mod api;
 pub mod git;
 pub mod graph;
+pub mod land;
 pub mod markdown;
 pub mod persist;
 pub mod tree;
@@ -8,7 +9,7 @@ pub mod util;
 
 pub struct Credentials {
     // Personal access token
-    token: String,
+    pub(crate) token: String,
 }
 
 impl Credentials {

--- a/src/main.rs
+++ b/src/main.rs
@@ -250,12 +250,11 @@ fn resolve_repository(
         return Ok(repo);
     }
 
-    Err(format!(
-        "Could not determine repository. Either:\n  \
+    Err("Could not determine repository. Either:\n  \
          - Run from inside a git repo with a GitHub remote\n  \
          - Set GHSTACK_TARGET_REPOSITORY environment variable\n  \
          - Use the -r flag"
-    ))
+        .to_string())
 }
 
 fn remove_title_prefixes(title: String, prefix: &str) -> String {

--- a/src/tree.rs
+++ b/src/tree.rs
@@ -97,7 +97,7 @@ fn parse_github_remote_url(url: &str) -> Option<String> {
     if url.starts_with("https://") || url.starts_with("http://") {
         let without_protocol = url.split("://").nth(1)?;
         // Skip the host part, get everything after first /
-        let path = without_protocol.splitn(2, '/').nth(1)?;
+        let path = without_protocol.split_once('/')?.1;
         let repo = path.trim_end_matches(".git");
         return Some(repo.to_string());
     }


### PR DESCRIPTION
## Summary

Adds a new `land` subcommand that intelligently merges a stack of PRs using the spr/Graphite optimization pattern, plus automatic repository detection from git remotes.

## How it works

1. Finds the topmost PR where all PRs below it are approved
2. Updates that PR's base to the target branch (main/master)  
3. Squash-merges that single PR (contains all commits from the stack)
4. Closes all PRs below it with a "Landed via #N" comment

## Usage

```bash
# Auto-detects repository from git remote - no -r flag needed!
gh-stack land PROJ-123

# Preview what would happen
gh-stack land PROJ-123 --dry-run

# Skip approval checks
gh-stack land PROJ-123 --no-approval

# Only land bottom 2 PRs
gh-stack land PROJ-123 --count 2

# Use a different remote (default: origin)
gh-stack land PROJ-123 --origin upstream

# Override auto-detection with explicit repo
gh-stack land PROJ-123 -r owner/repo
```

## Features

### Land Command
- `--dry-run`: Preview what would happen without making changes
- `--no-approval`: Skip approval requirement check  
- `--count N`: Only land bottom N PRs in the stack
- Draft PRs block landing of PRs above them
- Clear error messages with hints for resolution

### Auto-detect Repository (NEW)
- Automatically detects `owner/repo` from git remote URL
- Works with SSH and HTTPS URLs (including GitHub Enterprise)
- Fallback chain: `-r` flag → `GHSTACK_TARGET_REPOSITORY` env var → auto-detect
- `--origin` / `-o` flag to specify which remote to use (defaults to "origin")
- Prints detection message: `Detected repository: owner/repo (from origin remote)`
- Applied to all commands: `annotate`, `log`, `autorebase`, `land`

## Changes

- New `src/land.rs` module with landing logic
- New `src/api/land.rs` module with GitHub API methods for merge/close/update
- Added `land` subcommand to CLI in `main.rs`
- Added `parse_github_remote_url()` and `detect_repo_from_remote()` in `src/tree.rs`
- Added `resolve_repository()` helper with fallback chain in `main.rs`
- Added `--origin` flag to `annotate`, `log`, `autorebase`, and `land` commands
- Added `serial_test` dev dependency for API mock tests
- 9 new unit tests for land planning logic
- 9 new unit tests for URL parsing
- 3 new integration tests for API methods