### PR TITLE
[status-command] Add head_sha/html_url accessors to PullRequest

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -420,7 +420,7 @@ dependencies = [
 
 [[package]]
 name = "gh-stack"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "chrono",
  "clap",


### PR DESCRIPTION
## Summary

- Add `head_sha()` accessor for commit SHA (needed for check status lookups)
- Add `raw_title()` accessor for unformatted title display
- Add `html_url()` method to convert API URLs to web URLs
- Handle both github.com and enterprise GitHub URLs

## Tests

5 unit tests added for the new accessors.

---
*Part 1 of 5 in the status-command stack*
<!---GHSTACKOPEN-->
### Stacked PR Chain: status-command
| PR | Title | Merges Into |
|:--:|:------|:-----------:|
|#30|👉Add head_sha/html_url accessors to PullRequest|-|
|#31|Add GitHub Checks API module|#30|
|#32|Add status module with core logic and rendering|#31|
|#33|Add status subcommand and log --status flag|#32|
|#34|Add status command documentation|#33|
<!---GHSTACKCLOSE-->
