### PR TITLE
[status-command] Add status command documentation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -437,6 +437,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serial_test",
+ "tempfile",
  "tokio",
  "tokio-test",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -420,7 +420,7 @@ dependencies = [
 
 [[package]]
 name = "gh-stack"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "chrono",
  "clap",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -231,6 +231,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "dirs"
+version = "5.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44c45a9d03d6676652bcb5e724c7e988de1acad23a711b5217ab9cbecbec2225"
+dependencies = [
+ "dirs-sys",
+]
+
+[[package]]
+name = "dirs-sys"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "520f05a5cbd335fae5a99ff7a6ab8627577660ee5cfd6a94a6a929b52ff0321c"
+dependencies = [
+ "libc",
+ "option-ext",
+ "redox_users",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
 name = "displaydoc"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -426,6 +447,7 @@ dependencies = [
  "clap",
  "console",
  "dialoguer",
+ "dirs",
  "dotenvy",
  "futures",
  "git2",
@@ -875,6 +897,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "libredox"
+version = "0.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d0b95e02c851351f877147b7deea7b1afb1df71b63aa5f8270716e0c5720616"
+dependencies = [
+ "bitflags 2.10.0",
+ "libc",
+]
+
+[[package]]
 name = "libz-sys"
 version = "1.1.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -972,6 +1004,12 @@ name = "once_cell"
 version = "1.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
+
+[[package]]
+name = "option-ext"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
 name = "parking_lot"
@@ -1155,6 +1193,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
  "bitflags 2.10.0",
+]
+
+[[package]]
+name = "redox_users"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba009ff324d1fc1b900bd1fdb31564febe58a8ccc8a6fdbb93b543d33b13ca43"
+dependencies = [
+ "getrandom 0.2.16",
+ "libredox",
+ "thiserror",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,4 +31,5 @@ chrono = { version = "0.4", features = ["serde"] }
 insta = "1.39"
 mockito = "1.4"
 serial_test = "3.1"
+tempfile = "3"
 tokio-test = "0.4"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,7 @@ petgraph = "0.6"
 regex = "1"
 git2 = { version = "0.18", default-features = false }
 dialoguer = "0.11"
+dirs = "5"
 clap = "2.34"
 console = "0.15"
 dotenvy = "0.15"

--- a/docs/status.md
+++ b/docs/status.md
@@ -1,0 +1,157 @@
+# gh-stack status
+
+Show stack status with CI, approval, and merge readiness indicators.
+
+## Usage
+
+```bash
+gh-stack status <identifier> [OPTIONS]
+# or
+gh-stack log --status <identifier> [OPTIONS]
+```
+
+## Description
+
+The `status` command displays your PR stack with status bits showing:
+
+1. **CI checks** - Whether CI/GitHub Actions are passing
+2. **Approved** - Whether the PR has been approved
+3. **Mergeable** - Whether the PR has merge conflicts
+4. **Stack clear** - Whether all PRs below are approved and not draft
+
+## Output Format
+
+### Default (Unicode)
+
+```
+◉ feature-3 (current) #125 - Add final feature component...
+│ [✓ ✗ ✓ ✗]  2 hours ago
+│
+│ - abc1234 Add widget component
+│ - def5678 Update styles
+│ + 2 more
+│
+◯ feature-2 #124 - Implement API endpoint
+│ [✓ ✓ ✓ ✓]  1 day ago
+│
+◯ feature-1 #123 - Setup base infrastructure
+│ [✓ ✓ ✗ ✓]  3 days ago
+│
+◯ main
+
+Status: [CI | Approved | Mergeable | Stack]
+  ✓ pass  ✗ fail  ⏳ pending  ─ n/a
+```
+
+### ASCII mode (--no-color)
+
+```
+* feature-3 (current) #125 - Add final feature component...
+| [Y N Y N]  2 hours ago
+|
+o main
+
+Status: [CI | Approved | Mergeable | Stack]
+  Y=pass  N=fail  ?=pending  -=n/a
+```
+
+## Status Bits
+
+| Position | Meaning | Pass | Fail | Pending |
+|----------|---------|------|------|---------|
+| 1st | CI checks | All checks pass | Any check failed | Checks running |
+| 2nd | Approved | Has approval | No approval | - |
+| 3rd | Mergeable | No conflicts | Has conflicts | Computing |
+| 4th | Stack clear | All below approved | Blocked by PR below | - |
+
+## Options
+
+| Flag | Description |
+|------|-------------|
+| `--no-checks` | Skip fetching CI/approval/conflict status (faster, shows basic tree) |
+| `--no-color` | Disable colors and Unicode characters |
+| `--help-legend` | Show status bits legend |
+| `--json` | Output in JSON format |
+| `-C, --project <PATH>` | Path to local repository |
+| `-r, --repository <REPO>` | Specify repository (owner/repo) |
+| `-o, --origin <REMOTE>` | Git remote to use (default: origin) |
+| `-e, --excl <NUMBER>` | Exclude PR by number (can be used multiple times) |
+
+## JSON Output
+
+```bash
+gh-stack status STACK-123 --json
+```
+
+```json
+{
+  "stack": [
+    {
+      "branch": "feature-3",
+      "pr_number": 125,
+      "title": "Add final feature component",
+      "is_current": true,
+      "is_draft": false,
+      "status": {
+        "ci": "passed",
+        "approved": "failed",
+        "mergeable": "passed",
+        "stack_clear": "failed"
+      },
+      "updated_at": "2024-01-15T10:30:00Z",
+      "commits": [
+        {"sha": "abc1234", "message": "Add widget component"}
+      ]
+    }
+  ],
+  "trunk": "main"
+}
+```
+
+## Legend
+
+The legend is shown automatically on first run. To see it again:
+
+```bash
+gh-stack status STACK-123 --help-legend
+```
+
+The legend marker is stored in `~/.gh-stack-legend-seen`.
+
+## Examples
+
+### Basic usage
+
+```bash
+gh-stack status JIRA-1234
+```
+
+### Skip API calls for faster output
+
+```bash
+gh-stack status JIRA-1234 --no-checks
+```
+
+### Specify repository explicitly
+
+```bash
+gh-stack status JIRA-1234 -r owner/repo
+```
+
+### Output as JSON for scripting
+
+```bash
+gh-stack status JIRA-1234 --json | jq '.stack[].status.ci'
+```
+
+### Use with log command
+
+```bash
+gh-stack log --status JIRA-1234
+```
+
+## See Also
+
+- [log](log.md) - Basic tree view without status bits
+- [land](land.md) - Land a stack of PRs
+- [annotate](annotate.md) - Annotate PRs with stack information

--- a/src/api/checks.rs
+++ b/src/api/checks.rs
@@ -1,0 +1,528 @@
+//! GitHub Checks API for CI status
+//!
+//! This module provides functions to fetch CI check status and PR mergeable state
+//! from the GitHub API.
+
+use reqwest::Client;
+use serde::Deserialize;
+use std::error::Error;
+use std::time::Duration;
+
+use crate::Credentials;
+
+/// Overall state of CI checks for a commit
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub enum CheckState {
+    /// All checks passed
+    Success,
+    /// At least one check failed
+    Failure,
+    /// Checks are still running
+    Pending,
+    /// No checks or all skipped/neutral
+    Neutral,
+}
+
+/// Aggregated check status for a commit
+#[derive(Debug, Clone)]
+pub struct CheckStatus {
+    pub state: CheckState,
+    pub total: usize,
+    pub passed: usize,
+    pub failed: usize,
+    pub pending: usize,
+}
+
+impl CheckStatus {
+    /// Create a neutral status (no checks)
+    pub fn neutral() -> Self {
+        CheckStatus {
+            state: CheckState::Neutral,
+            total: 0,
+            passed: 0,
+            failed: 0,
+            pending: 0,
+        }
+    }
+}
+
+/// Response from GitHub check-runs API
+#[derive(Deserialize, Debug)]
+struct CheckRunsResponse {
+    total_count: usize,
+    check_runs: Vec<CheckRun>,
+}
+
+/// Individual check run from GitHub API
+#[derive(Deserialize, Debug)]
+struct CheckRun {
+    /// "completed", "in_progress", "queued", "pending"
+    status: String,
+    /// "success", "failure", "neutral", "cancelled", "skipped", "timed_out", "action_required"
+    conclusion: Option<String>,
+}
+
+/// Response from GitHub PR API (for mergeable field)
+#[derive(Deserialize, Debug)]
+struct PrMergeableResponse {
+    mergeable: Option<bool>,
+}
+
+fn build_get_request(
+    client: &Client,
+    credentials: &Credentials,
+    url: &str,
+) -> reqwest::RequestBuilder {
+    client
+        .get(url)
+        .timeout(Duration::from_secs(10))
+        .header("Authorization", format!("token {}", credentials.token))
+        .header("User-Agent", "luqven/gh-stack")
+        .header("Accept", "application/vnd.github.v3+json")
+}
+
+/// Fetch check status for a commit SHA
+///
+/// # Arguments
+/// * `sha` - The commit SHA to check
+/// * `repo` - Repository in "owner/repo" format
+/// * `credentials` - GitHub credentials
+pub async fn fetch_check_status(
+    sha: &str,
+    repo: &str,
+    credentials: &Credentials,
+) -> Result<CheckStatus, Box<dyn Error>> {
+    let client = Client::new();
+    let url = format!(
+        "{}/repos/{}/commits/{}/check-runs",
+        super::github_api_base(),
+        repo,
+        sha
+    );
+
+    let response = build_get_request(&client, credentials, &url).send().await?;
+
+    if response.status() == 429 {
+        return Err("GitHub API rate limit exceeded".into());
+    }
+
+    if !response.status().is_success() {
+        let status = response.status();
+        let text = response.text().await.unwrap_or_default();
+        return Err(format!("Failed to fetch check status ({}): {}", status, text).into());
+    }
+
+    let check_runs: CheckRunsResponse = response.json().await?;
+    Ok(parse_check_runs(&check_runs))
+}
+
+/// Parse check runs response into aggregated status
+fn parse_check_runs(response: &CheckRunsResponse) -> CheckStatus {
+    if response.total_count == 0 {
+        return CheckStatus::neutral();
+    }
+
+    let mut passed = 0;
+    let mut failed = 0;
+    let mut pending = 0;
+
+    for run in &response.check_runs {
+        match run.status.as_str() {
+            "completed" => {
+                match run.conclusion.as_deref() {
+                    Some("success") | Some("neutral") | Some("skipped") => passed += 1,
+                    Some("failure")
+                    | Some("timed_out")
+                    | Some("cancelled")
+                    | Some("action_required") => failed += 1,
+                    _ => pending += 1, // Unknown conclusion treated as pending
+                }
+            }
+            _ => pending += 1, // in_progress, queued, pending, or unknown
+        }
+    }
+
+    let state = if failed > 0 {
+        CheckState::Failure
+    } else if pending > 0 {
+        CheckState::Pending
+    } else if passed > 0 {
+        CheckState::Success
+    } else {
+        CheckState::Neutral
+    };
+
+    CheckStatus {
+        state,
+        total: response.total_count,
+        passed,
+        failed,
+        pending,
+    }
+}
+
+/// Fetch mergeable status for a PR
+///
+/// GitHub computes mergeability asynchronously, so this may return None
+/// if GitHub is still calculating.
+///
+/// # Arguments
+/// * `pr_number` - The PR number
+/// * `repo` - Repository in "owner/repo" format
+/// * `credentials` - GitHub credentials
+pub async fn fetch_mergeable_status(
+    pr_number: usize,
+    repo: &str,
+    credentials: &Credentials,
+) -> Result<Option<bool>, Box<dyn Error>> {
+    let client = Client::new();
+    let url = format!(
+        "{}/repos/{}/pulls/{}",
+        super::github_api_base(),
+        repo,
+        pr_number
+    );
+
+    let response = build_get_request(&client, credentials, &url).send().await?;
+
+    if response.status() == 429 {
+        return Err("GitHub API rate limit exceeded".into());
+    }
+
+    if !response.status().is_success() {
+        let status = response.status();
+        let text = response.text().await.unwrap_or_default();
+        return Err(format!("Failed to fetch PR mergeable status ({}): {}", status, text).into());
+    }
+
+    let pr: PrMergeableResponse = response.json().await?;
+    Ok(pr.mergeable)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use mockito::Server;
+    use serial_test::serial;
+
+    // === Unit tests for parsing ===
+
+    #[test]
+    fn test_parse_check_runs_all_success() {
+        let response = CheckRunsResponse {
+            total_count: 3,
+            check_runs: vec![
+                CheckRun {
+                    status: "completed".to_string(),
+                    conclusion: Some("success".to_string()),
+                },
+                CheckRun {
+                    status: "completed".to_string(),
+                    conclusion: Some("success".to_string()),
+                },
+                CheckRun {
+                    status: "completed".to_string(),
+                    conclusion: Some("success".to_string()),
+                },
+            ],
+        };
+
+        let status = parse_check_runs(&response);
+        assert_eq!(status.state, CheckState::Success);
+        assert_eq!(status.total, 3);
+        assert_eq!(status.passed, 3);
+        assert_eq!(status.failed, 0);
+        assert_eq!(status.pending, 0);
+    }
+
+    #[test]
+    fn test_parse_check_runs_mixed() {
+        let response = CheckRunsResponse {
+            total_count: 3,
+            check_runs: vec![
+                CheckRun {
+                    status: "completed".to_string(),
+                    conclusion: Some("success".to_string()),
+                },
+                CheckRun {
+                    status: "completed".to_string(),
+                    conclusion: Some("failure".to_string()),
+                },
+                CheckRun {
+                    status: "in_progress".to_string(),
+                    conclusion: None,
+                },
+            ],
+        };
+
+        let status = parse_check_runs(&response);
+        assert_eq!(status.state, CheckState::Failure); // Failure takes precedence
+        assert_eq!(status.total, 3);
+        assert_eq!(status.passed, 1);
+        assert_eq!(status.failed, 1);
+        assert_eq!(status.pending, 1);
+    }
+
+    #[test]
+    fn test_parse_check_runs_all_pending() {
+        let response = CheckRunsResponse {
+            total_count: 2,
+            check_runs: vec![
+                CheckRun {
+                    status: "in_progress".to_string(),
+                    conclusion: None,
+                },
+                CheckRun {
+                    status: "queued".to_string(),
+                    conclusion: None,
+                },
+            ],
+        };
+
+        let status = parse_check_runs(&response);
+        assert_eq!(status.state, CheckState::Pending);
+        assert_eq!(status.total, 2);
+        assert_eq!(status.passed, 0);
+        assert_eq!(status.failed, 0);
+        assert_eq!(status.pending, 2);
+    }
+
+    #[test]
+    fn test_parse_check_runs_empty() {
+        let response = CheckRunsResponse {
+            total_count: 0,
+            check_runs: vec![],
+        };
+
+        let status = parse_check_runs(&response);
+        assert_eq!(status.state, CheckState::Neutral);
+        assert_eq!(status.total, 0);
+    }
+
+    #[test]
+    fn test_parse_check_runs_neutral_conclusion() {
+        let response = CheckRunsResponse {
+            total_count: 2,
+            check_runs: vec![
+                CheckRun {
+                    status: "completed".to_string(),
+                    conclusion: Some("neutral".to_string()),
+                },
+                CheckRun {
+                    status: "completed".to_string(),
+                    conclusion: Some("skipped".to_string()),
+                },
+            ],
+        };
+
+        let status = parse_check_runs(&response);
+        assert_eq!(status.state, CheckState::Success); // Neutral/skipped count as passed
+        assert_eq!(status.passed, 2);
+    }
+
+    #[test]
+    fn test_parse_check_runs_timed_out() {
+        let response = CheckRunsResponse {
+            total_count: 1,
+            check_runs: vec![CheckRun {
+                status: "completed".to_string(),
+                conclusion: Some("timed_out".to_string()),
+            }],
+        };
+
+        let status = parse_check_runs(&response);
+        assert_eq!(status.state, CheckState::Failure);
+        assert_eq!(status.failed, 1);
+    }
+
+    #[test]
+    fn test_parse_check_runs_cancelled() {
+        let response = CheckRunsResponse {
+            total_count: 1,
+            check_runs: vec![CheckRun {
+                status: "completed".to_string(),
+                conclusion: Some("cancelled".to_string()),
+            }],
+        };
+
+        let status = parse_check_runs(&response);
+        assert_eq!(status.state, CheckState::Failure);
+        assert_eq!(status.failed, 1);
+    }
+
+    // === Async/mock tests ===
+
+    #[tokio::test]
+    #[serial]
+    async fn test_fetch_check_status_success() {
+        let mut server = Server::new_async().await;
+
+        let mock = server
+            .mock("GET", "/repos/owner/repo/commits/abc123/check-runs")
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body(
+                r#"{
+                    "total_count": 2,
+                    "check_runs": [
+                        {"status": "completed", "conclusion": "success"},
+                        {"status": "completed", "conclusion": "success"}
+                    ]
+                }"#,
+            )
+            .create_async()
+            .await;
+
+        std::env::set_var("GITHUB_API_BASE", server.url());
+
+        let creds = Credentials::new("test-token");
+        let result = fetch_check_status("abc123", "owner/repo", &creds).await;
+
+        assert!(result.is_ok());
+        let status = result.unwrap();
+        assert_eq!(status.state, CheckState::Success);
+        assert_eq!(status.passed, 2);
+
+        mock.assert_async().await;
+    }
+
+    #[tokio::test]
+    #[serial]
+    async fn test_fetch_check_status_rate_limited() {
+        let mut server = Server::new_async().await;
+
+        let mock = server
+            .mock("GET", "/repos/owner/repo/commits/abc123/check-runs")
+            .with_status(429)
+            .with_body("rate limit exceeded")
+            .create_async()
+            .await;
+
+        std::env::set_var("GITHUB_API_BASE", server.url());
+
+        let creds = Credentials::new("test-token");
+        let result = fetch_check_status("abc123", "owner/repo", &creds).await;
+
+        assert!(result.is_err());
+        assert!(result.unwrap_err().to_string().contains("rate limit"));
+
+        mock.assert_async().await;
+    }
+
+    #[tokio::test]
+    #[serial]
+    async fn test_fetch_check_status_api_error() {
+        let mut server = Server::new_async().await;
+
+        let mock = server
+            .mock("GET", "/repos/owner/repo/commits/abc123/check-runs")
+            .with_status(404)
+            .with_body("not found")
+            .create_async()
+            .await;
+
+        std::env::set_var("GITHUB_API_BASE", server.url());
+
+        let creds = Credentials::new("test-token");
+        let result = fetch_check_status("abc123", "owner/repo", &creds).await;
+
+        assert!(result.is_err());
+
+        mock.assert_async().await;
+    }
+
+    #[tokio::test]
+    #[serial]
+    async fn test_fetch_mergeable_status_true() {
+        let mut server = Server::new_async().await;
+
+        let mock = server
+            .mock("GET", "/repos/owner/repo/pulls/123")
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body(r#"{"mergeable": true}"#)
+            .create_async()
+            .await;
+
+        std::env::set_var("GITHUB_API_BASE", server.url());
+
+        let creds = Credentials::new("test-token");
+        let result = fetch_mergeable_status(123, "owner/repo", &creds).await;
+
+        assert!(result.is_ok());
+        assert_eq!(result.unwrap(), Some(true));
+
+        mock.assert_async().await;
+    }
+
+    #[tokio::test]
+    #[serial]
+    async fn test_fetch_mergeable_status_false() {
+        let mut server = Server::new_async().await;
+
+        let mock = server
+            .mock("GET", "/repos/owner/repo/pulls/123")
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body(r#"{"mergeable": false}"#)
+            .create_async()
+            .await;
+
+        std::env::set_var("GITHUB_API_BASE", server.url());
+
+        let creds = Credentials::new("test-token");
+        let result = fetch_mergeable_status(123, "owner/repo", &creds).await;
+
+        assert!(result.is_ok());
+        assert_eq!(result.unwrap(), Some(false));
+
+        mock.assert_async().await;
+    }
+
+    #[tokio::test]
+    #[serial]
+    async fn test_fetch_mergeable_status_null() {
+        let mut server = Server::new_async().await;
+
+        let mock = server
+            .mock("GET", "/repos/owner/repo/pulls/123")
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body(r#"{"mergeable": null}"#)
+            .create_async()
+            .await;
+
+        std::env::set_var("GITHUB_API_BASE", server.url());
+
+        let creds = Credentials::new("test-token");
+        let result = fetch_mergeable_status(123, "owner/repo", &creds).await;
+
+        assert!(result.is_ok());
+        assert_eq!(result.unwrap(), None);
+
+        mock.assert_async().await;
+    }
+
+    #[tokio::test]
+    #[serial]
+    async fn test_fetch_mergeable_status_rate_limited() {
+        let mut server = Server::new_async().await;
+
+        let mock = server
+            .mock("GET", "/repos/owner/repo/pulls/123")
+            .with_status(429)
+            .with_body("rate limit exceeded")
+            .create_async()
+            .await;
+
+        std::env::set_var("GITHUB_API_BASE", server.url());
+
+        let creds = Credentials::new("test-token");
+        let result = fetch_mergeable_status(123, "owner/repo", &creds).await;
+
+        assert!(result.is_err());
+        assert!(result.unwrap_err().to_string().contains("rate limit"));
+
+        mock.assert_async().await;
+    }
+}

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -2,6 +2,7 @@ use crate::Credentials;
 use reqwest::{Client, RequestBuilder};
 use std::time::Duration;
 
+pub mod checks;
 pub mod land;
 pub mod pull_request;
 pub mod search;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,6 +4,7 @@ pub mod graph;
 pub mod land;
 pub mod markdown;
 pub mod persist;
+pub mod status;
 pub mod tree;
 pub mod util;
 

--- a/src/snapshots/gh_stack__status__tests__snapshot_status_all_passing.snap
+++ b/src/snapshots/gh_stack__status__tests__snapshot_status_all_passing.snap
@@ -1,0 +1,11 @@
+---
+source: src/status.rs
+expression: output
+---
+* feature-2 (current) #124 - Add new feature
+| [Y Y Y Y]
+|
+o feature-1 #123 - Setup base
+| [Y Y Y Y]
+|
+o main

--- a/src/snapshots/gh_stack__status__tests__snapshot_status_json.snap
+++ b/src/snapshots/gh_stack__status__tests__snapshot_status_json.snap
@@ -1,0 +1,30 @@
+---
+source: src/status.rs
+expression: output
+---
+{
+  "stack": [
+    {
+      "branch": "feature-1",
+      "pr_number": 123,
+      "title": "Add feature",
+      "is_current": true,
+      "is_draft": false,
+      "is_trunk": false,
+      "status": {
+        "ci": "passed",
+        "approved": "passed",
+        "mergeable": "passed",
+        "stack_clear": "passed"
+      },
+      "updated_at": "2024-01-15T10:30:00Z",
+      "commits": [
+        {
+          "sha": "abc1234",
+          "message": "Add widget"
+        }
+      ]
+    }
+  ],
+  "trunk": "main"
+}

--- a/src/snapshots/gh_stack__status__tests__snapshot_status_mixed.snap
+++ b/src/snapshots/gh_stack__status__tests__snapshot_status_mixed.snap
@@ -1,0 +1,11 @@
+---
+source: src/status.rs
+expression: output
+---
+* feature-2 (current) #124 - Add new feature
+| [? N Y N]
+|
+o feature-1 #123 - Setup base
+| [Y Y N Y]
+|
+o main

--- a/src/snapshots/gh_stack__status__tests__snapshot_status_no_checks.snap
+++ b/src/snapshots/gh_stack__status__tests__snapshot_status_no_checks.snap
@@ -1,0 +1,9 @@
+---
+source: src/status.rs
+expression: output
+---
+* feature-2 (current) #124 - Add new feature
+|
+o feature-1 #123 - Setup base
+|
+o main

--- a/src/snapshots/gh_stack__status__tests__snapshot_status_single_pr.snap
+++ b/src/snapshots/gh_stack__status__tests__snapshot_status_single_pr.snap
@@ -1,0 +1,8 @@
+---
+source: src/status.rs
+expression: output
+---
+o feature-1 #123 - Single PR
+| [Y Y Y Y]
+|
+o main

--- a/src/snapshots/gh_stack__status__tests__snapshot_status_unicode.snap
+++ b/src/snapshots/gh_stack__status__tests__snapshot_status_unicode.snap
@@ -1,0 +1,8 @@
+---
+source: src/status.rs
+expression: output
+---
+◉ feature-1 (current) #123 - Add feature
+│ [✓ ✗ ⏳ ─]
+│
+◯ main

--- a/src/snapshots/gh_stack__status__tests__snapshot_status_with_commits.snap
+++ b/src/snapshots/gh_stack__status__tests__snapshot_status_with_commits.snap
@@ -1,0 +1,12 @@
+---
+source: src/status.rs
+expression: output
+---
+* feature-1 (current) #123 - Add feature
+| [Y Y Y Y]
+|
+| abc1234 - Add widget component
+| def5678 - Update styles
+| + 2 more
+|
+o main

--- a/src/snapshots/gh_stack__status__tests__snapshot_status_with_draft.snap
+++ b/src/snapshots/gh_stack__status__tests__snapshot_status_with_draft.snap
@@ -1,0 +1,11 @@
+---
+source: src/status.rs
+expression: output
+---
+* wip-feature (current) #125 - Work in progress (draft)
+| [? N Y N]
+|
+o feature-1 #123 - Setup base
+| [Y Y Y Y]
+|
+o main

--- a/src/snapshots/gh_stack__status__tests__snapshot_status_with_legend.snap
+++ b/src/snapshots/gh_stack__status__tests__snapshot_status_with_legend.snap
@@ -1,0 +1,11 @@
+---
+source: src/status.rs
+expression: output
+---
+o feature-1 #123 - Add feature
+| [Y Y Y Y]
+|
+o main
+
+Status: [CI | Approved | Mergeable | Stack]
+  Y=pass  N=fail  ?=pending  -=n/a

--- a/src/status.rs
+++ b/src/status.rs
@@ -1,0 +1,1395 @@
+//! Status display logic for PR stacks
+//!
+//! This module provides functionality to display stack status with CI, approval,
+//! merge, and stack health indicators.
+
+use std::path::PathBuf;
+
+use git2::Repository;
+use serde::Serialize;
+
+use crate::api::checks::{fetch_check_status, fetch_mergeable_status, CheckState, CheckStatus};
+use crate::api::{PullRequest, PullRequestReviewState};
+use crate::graph::FlatDep;
+use crate::tree::{
+    branch_exists_locally, commits_for_branch, current_branch, format_relative_time,
+    parse_timestamp, CommitInfo,
+};
+use crate::Credentials;
+
+const MAX_TITLE_LEN: usize = 50;
+const LEGEND_FILE_NAME: &str = ".gh-stack-legend-seen";
+
+/// Individual status bit result
+#[derive(Debug, Clone, Copy, PartialEq, Serialize)]
+#[serde(rename_all = "lowercase")]
+pub enum StatusBit {
+    Passed,
+    Failed,
+    Pending,
+    #[serde(rename = "n/a")]
+    NotApplicable,
+}
+
+impl StatusBit {
+    /// Convert to unicode symbol
+    pub fn to_unicode(&self) -> &'static str {
+        match self {
+            StatusBit::Passed => "✓",
+            StatusBit::Failed => "✗",
+            StatusBit::Pending => "⏳",
+            StatusBit::NotApplicable => "─",
+        }
+    }
+
+    /// Convert to ASCII symbol
+    pub fn to_ascii(&self) -> &'static str {
+        match self {
+            StatusBit::Passed => "Y",
+            StatusBit::Failed => "N",
+            StatusBit::Pending => "?",
+            StatusBit::NotApplicable => "-",
+        }
+    }
+}
+
+/// Aggregated status for a single PR
+#[derive(Debug, Clone, Serialize)]
+pub struct PrStatus {
+    pub ci: StatusBit,
+    pub approved: StatusBit,
+    pub mergeable: StatusBit,
+    pub stack_clear: StatusBit,
+}
+
+impl PrStatus {
+    /// Create a status with all bits set to NotApplicable
+    pub fn not_applicable() -> Self {
+        PrStatus {
+            ci: StatusBit::NotApplicable,
+            approved: StatusBit::NotApplicable,
+            mergeable: StatusBit::NotApplicable,
+            stack_clear: StatusBit::NotApplicable,
+        }
+    }
+}
+
+/// Extended entry with status information
+#[derive(Debug, Clone, Serialize)]
+pub struct StatusEntry {
+    pub branch: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub pr_number: Option<usize>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub title: Option<String>,
+    pub is_current: bool,
+    pub is_draft: bool,
+    pub is_trunk: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub status: Option<PrStatus>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub updated_at: Option<String>,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub commits: Vec<CommitInfo>,
+    #[serde(skip_serializing_if = "is_zero")]
+    pub extra_commits: usize,
+}
+
+fn is_zero(n: &usize) -> bool {
+    *n == 0
+}
+
+/// Configuration for status display
+#[derive(Debug, Clone)]
+pub struct StatusConfig {
+    pub use_color: bool,
+    pub use_unicode: bool,
+    pub show_legend: bool,
+    pub include_checks: bool,
+    pub json_output: bool,
+}
+
+impl Default for StatusConfig {
+    fn default() -> Self {
+        StatusConfig {
+            use_color: true,
+            use_unicode: true,
+            show_legend: false,
+            include_checks: true,
+            json_output: false,
+        }
+    }
+}
+
+/// JSON output structure
+#[derive(Debug, Serialize)]
+pub struct StatusOutput {
+    pub stack: Vec<StatusEntry>,
+    pub trunk: String,
+}
+
+/// Get the path to the legend seen file
+fn legend_file_path() -> Option<PathBuf> {
+    dirs::home_dir().map(|h| h.join(LEGEND_FILE_NAME))
+}
+
+/// Check if we should show the legend (first run detection)
+pub fn should_show_legend() -> bool {
+    match legend_file_path() {
+        Some(path) if path.exists() => false,
+        Some(path) => {
+            // Create marker file
+            let _ = std::fs::write(&path, "1");
+            true
+        }
+        None => true, // Show if can't determine
+    }
+}
+
+/// Mark legend as seen (create the marker file)
+pub fn mark_legend_seen() {
+    if let Some(path) = legend_file_path() {
+        let _ = std::fs::write(&path, "1");
+    }
+}
+
+/// Truncate title to max length with "..."
+pub fn truncate_title(title: &str, max_len: usize) -> String {
+    if title.chars().count() <= max_len {
+        title.to_string()
+    } else {
+        let truncated: String = title.chars().take(max_len.saturating_sub(3)).collect();
+        format!("{}...", truncated)
+    }
+}
+
+/// Convert CheckStatus to StatusBit
+fn check_status_to_bit(status: &CheckStatus) -> StatusBit {
+    match status.state {
+        CheckState::Success => StatusBit::Passed,
+        CheckState::Failure => StatusBit::Failed,
+        CheckState::Pending => StatusBit::Pending,
+        CheckState::Neutral => StatusBit::NotApplicable,
+    }
+}
+
+/// Convert approval state to StatusBit
+fn approval_to_bit(pr: &PullRequest) -> StatusBit {
+    match pr.review_state() {
+        PullRequestReviewState::APPROVED | PullRequestReviewState::MERGED => StatusBit::Passed,
+        _ => StatusBit::Failed,
+    }
+}
+
+/// Convert mergeable state to StatusBit
+fn mergeable_to_bit(mergeable: Option<bool>) -> StatusBit {
+    match mergeable {
+        Some(true) => StatusBit::Passed,
+        Some(false) => StatusBit::Failed,
+        None => StatusBit::Pending,
+    }
+}
+
+/// Compute stack clear status for a PR at given index
+/// A PR is "stack clear" if all PRs below it are approved and not draft
+fn compute_stack_clear(entries: &[StatusEntry], index: usize) -> StatusBit {
+    // Check all entries below this one (higher indices = lower in stack)
+    for entry in entries.iter().skip(index + 1) {
+        if entry.is_trunk {
+            continue;
+        }
+
+        // If any PR below is draft, stack is blocked
+        if entry.is_draft {
+            return StatusBit::Failed;
+        }
+
+        // If any PR below is not approved, stack is blocked
+        if let Some(status) = &entry.status {
+            if status.approved != StatusBit::Passed {
+                return StatusBit::Failed;
+            }
+        }
+    }
+
+    // Also check if this PR itself is approved (can't be stack clear if not approved)
+    if let Some(entry) = entries.get(index) {
+        if entry.is_draft {
+            return StatusBit::Failed;
+        }
+        if let Some(status) = &entry.status {
+            if status.approved != StatusBit::Passed {
+                return StatusBit::Failed;
+            }
+        }
+    }
+
+    StatusBit::Passed
+}
+
+/// Build status entries from a PR stack
+pub async fn build_status_entries(
+    stack: &FlatDep,
+    repo: Option<&Repository>,
+    repository: &str,
+    credentials: &Credentials,
+    config: &StatusConfig,
+) -> Vec<StatusEntry> {
+    let current = repo.and_then(current_branch);
+    let mut entries = Vec::new();
+
+    // Get trunk branch from first PR's base
+    let trunk_branch = stack.first().map(|(pr, _)| pr.base().to_string());
+
+    // Process PRs in reverse order (top of stack first)
+    for (pr, _parent) in stack.iter().rev() {
+        // Skip closed/merged PRs
+        if pr.is_merged() || pr.state() == &crate::api::PullRequestStatus::Closed {
+            continue;
+        }
+
+        let is_current = current.as_ref().is_some_and(|c| c == pr.head());
+        let timestamp = pr.updated_at().and_then(parse_timestamp);
+
+        // Get commits if we have a repo
+        let (commits, extra_commits) = if let Some(r) = repo {
+            if branch_exists_locally(r, pr.head()) {
+                commits_for_branch(r, pr.head(), pr.base())
+            } else {
+                (vec![], 0)
+            }
+        } else {
+            (vec![], 0)
+        };
+
+        // Fetch status if enabled
+        let status = if config.include_checks {
+            let ci = match fetch_check_status(pr.head_sha(), repository, credentials).await {
+                Ok(check) => check_status_to_bit(&check),
+                Err(_) => StatusBit::NotApplicable,
+            };
+
+            let mergeable = match fetch_mergeable_status(pr.number(), repository, credentials).await
+            {
+                Ok(m) => mergeable_to_bit(m),
+                Err(_) => StatusBit::NotApplicable,
+            };
+
+            Some(PrStatus {
+                ci,
+                approved: approval_to_bit(pr),
+                mergeable,
+                stack_clear: StatusBit::Pending, // Will be computed after all entries are built
+            })
+        } else {
+            None
+        };
+
+        entries.push(StatusEntry {
+            branch: pr.head().to_string(),
+            pr_number: Some(pr.number()),
+            title: Some(truncate_title(pr.raw_title(), MAX_TITLE_LEN)),
+            is_current,
+            is_draft: pr.is_draft(),
+            is_trunk: false,
+            status,
+            updated_at: timestamp.map(|t| t.to_rfc3339()),
+            commits,
+            extra_commits,
+        });
+    }
+
+    // Compute stack_clear for each entry (requires all entries to be built first)
+    if config.include_checks {
+        for i in 0..entries.len() {
+            let stack_clear = compute_stack_clear(&entries, i);
+            if let Some(status) = &mut entries[i].status {
+                status.stack_clear = stack_clear;
+            }
+        }
+    }
+
+    // Add trunk branch as final entry
+    if let Some(trunk) = trunk_branch {
+        let is_current = current.as_ref() == Some(&trunk);
+
+        entries.push(StatusEntry {
+            branch: trunk,
+            pr_number: None,
+            title: None,
+            is_current,
+            is_draft: false,
+            is_trunk: true,
+            status: None,
+            updated_at: None,
+            commits: vec![],
+            extra_commits: 0,
+        });
+    }
+
+    entries
+}
+
+/// Format status bits for display
+pub fn format_status_bits(status: &PrStatus, use_unicode: bool) -> String {
+    let bits = [
+        status.ci,
+        status.approved,
+        status.mergeable,
+        status.stack_clear,
+    ];
+
+    let symbols: Vec<&str> = bits
+        .iter()
+        .map(|b| {
+            if use_unicode {
+                b.to_unicode()
+            } else {
+                b.to_ascii()
+            }
+        })
+        .collect();
+
+    format!(
+        "[{} {} {} {}]",
+        symbols[0], symbols[1], symbols[2], symbols[3]
+    )
+}
+
+/// Format the legend text
+pub fn format_legend(use_unicode: bool) -> String {
+    let mut out = String::new();
+    out.push_str("\nStatus: [CI | Approved | Mergeable | Stack]\n");
+
+    if use_unicode {
+        out.push_str("  ✓ pass  ✗ fail  ⏳ pending  ─ n/a\n");
+    } else {
+        out.push_str("  Y=pass  N=fail  ?=pending  -=n/a\n");
+    }
+
+    out
+}
+
+/// Render status entries to string
+pub fn render_status(entries: &[StatusEntry], config: &StatusConfig, has_repo: bool) -> String {
+    use console::style;
+
+    let mut out = String::new();
+
+    // Symbols
+    let (current_node, other_node, pipe) = if config.use_unicode {
+        ("\u{25C9}", "\u{25EF}", "\u{2502}")
+    } else {
+        ("*", "o", "|")
+    };
+
+    for (i, entry) in entries.iter().enumerate() {
+        let is_last = i == entries.len() - 1;
+
+        // Node symbol
+        let node = if entry.is_current {
+            if config.use_color {
+                style(current_node).green().bold().to_string()
+            } else {
+                current_node.to_string()
+            }
+        } else if config.use_color {
+            style(other_node).dim().to_string()
+        } else {
+            other_node.to_string()
+        };
+
+        // Branch name with optional annotations
+        let mut branch_display = entry.branch.clone();
+        if entry.is_current {
+            branch_display = format!("{} (current)", branch_display);
+        }
+
+        // Add PR number and title if available
+        if let Some(pr_num) = entry.pr_number {
+            if let Some(title) = &entry.title {
+                branch_display = format!("{} #{} - {}", branch_display, pr_num, title);
+            } else {
+                branch_display = format!("{} #{}", branch_display, pr_num);
+            }
+        }
+
+        // Add draft indicator
+        if entry.is_draft {
+            branch_display = format!("{} (draft)", branch_display);
+        }
+
+        out.push_str(&format!("{} {}\n", node, branch_display));
+
+        // Connector for content below
+        let connector = if is_last { " " } else { pipe };
+
+        // Status bits (if available)
+        if let Some(status) = &entry.status {
+            let bits = format_status_bits(status, config.use_unicode);
+            let styled_bits = if config.use_color {
+                colorize_status_bits(status, config.use_unicode)
+            } else {
+                bits
+            };
+
+            // Add timestamp on same line as status
+            if let Some(updated_at) = &entry.updated_at {
+                if let Some(ts) = parse_timestamp(updated_at) {
+                    let time_str = format_relative_time(&ts);
+                    let styled_time = if config.use_color {
+                        style(&time_str).dim().to_string()
+                    } else {
+                        time_str
+                    };
+                    out.push_str(&format!("{} {}  {}\n", connector, styled_bits, styled_time));
+                } else {
+                    out.push_str(&format!("{} {}\n", connector, styled_bits));
+                }
+            } else {
+                out.push_str(&format!("{} {}\n", connector, styled_bits));
+            }
+        } else if let Some(updated_at) = &entry.updated_at {
+            // No status bits, just timestamp
+            if let Some(ts) = parse_timestamp(updated_at) {
+                let time_str = format_relative_time(&ts);
+                let styled_time = if config.use_color {
+                    style(&time_str).dim().to_string()
+                } else {
+                    time_str
+                };
+                out.push_str(&format!("{} {}\n", connector, styled_time));
+            }
+        }
+
+        // Commits (only for non-trunk entries with commits)
+        if !entry.commits.is_empty() {
+            out.push_str(&format!("{}\n", connector));
+            for commit in &entry.commits {
+                let commit_line = format!("{} - {}", commit.sha, commit.message);
+                let styled_commit = if config.use_color {
+                    style(&commit_line).dim().to_string()
+                } else {
+                    commit_line
+                };
+                out.push_str(&format!("{} {}\n", connector, styled_commit));
+            }
+
+            // Show "+ N more" if there are extra commits
+            if entry.extra_commits > 0 {
+                let more_text = format!("+ {} more", entry.extra_commits);
+                let styled_more = if config.use_color {
+                    style(&more_text).dim().to_string()
+                } else {
+                    more_text
+                };
+                out.push_str(&format!("{} {}\n", connector, styled_more));
+            }
+        }
+
+        // Empty line before next entry (except last)
+        if !is_last {
+            out.push_str(&format!("{}\n", pipe));
+        }
+    }
+
+    // Show legend if configured
+    if config.show_legend {
+        out.push_str(&format_legend(config.use_unicode));
+    }
+
+    // Hint if no repo detected
+    if !has_repo && !entries.is_empty() {
+        out.push_str(
+            "\nhint: run from a git repo or use -C <path> to see commits and current branch\n",
+        );
+    }
+
+    out
+}
+
+/// Colorize status bits with appropriate colors
+fn colorize_status_bits(status: &PrStatus, use_unicode: bool) -> String {
+    use console::style;
+
+    let colorize = |bit: StatusBit| -> String {
+        let symbol = if use_unicode {
+            bit.to_unicode()
+        } else {
+            bit.to_ascii()
+        };
+
+        match bit {
+            StatusBit::Passed => style(symbol).green().to_string(),
+            StatusBit::Failed => style(symbol).red().to_string(),
+            StatusBit::Pending => style(symbol).yellow().to_string(),
+            StatusBit::NotApplicable => style(symbol).dim().to_string(),
+        }
+    };
+
+    format!(
+        "[{} {} {} {}]",
+        colorize(status.ci),
+        colorize(status.approved),
+        colorize(status.mergeable),
+        colorize(status.stack_clear)
+    )
+}
+
+/// Render status entries as JSON
+pub fn render_status_json(entries: &[StatusEntry]) -> Result<String, serde_json::Error> {
+    let trunk = entries
+        .iter()
+        .find(|e| e.is_trunk)
+        .map(|e| e.branch.clone())
+        .unwrap_or_else(|| "main".to_string());
+
+    let stack: Vec<StatusEntry> = entries.iter().filter(|e| !e.is_trunk).cloned().collect();
+
+    let output = StatusOutput { stack, trunk };
+    serde_json::to_string_pretty(&output)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::api::{PullRequest, PullRequestStatus};
+    use tempfile::TempDir;
+
+    // === StatusBit tests ===
+
+    #[test]
+    fn test_status_bit_to_unicode() {
+        assert_eq!(StatusBit::Passed.to_unicode(), "✓");
+        assert_eq!(StatusBit::Failed.to_unicode(), "✗");
+        assert_eq!(StatusBit::Pending.to_unicode(), "⏳");
+        assert_eq!(StatusBit::NotApplicable.to_unicode(), "─");
+    }
+
+    #[test]
+    fn test_status_bit_to_ascii() {
+        assert_eq!(StatusBit::Passed.to_ascii(), "Y");
+        assert_eq!(StatusBit::Failed.to_ascii(), "N");
+        assert_eq!(StatusBit::Pending.to_ascii(), "?");
+        assert_eq!(StatusBit::NotApplicable.to_ascii(), "-");
+    }
+
+    // === CheckStatus to StatusBit tests ===
+
+    #[test]
+    fn test_check_status_to_bit_success() {
+        let status = CheckStatus {
+            state: CheckState::Success,
+            total: 1,
+            passed: 1,
+            failed: 0,
+            pending: 0,
+        };
+        assert_eq!(check_status_to_bit(&status), StatusBit::Passed);
+    }
+
+    #[test]
+    fn test_check_status_to_bit_failure() {
+        let status = CheckStatus {
+            state: CheckState::Failure,
+            total: 1,
+            passed: 0,
+            failed: 1,
+            pending: 0,
+        };
+        assert_eq!(check_status_to_bit(&status), StatusBit::Failed);
+    }
+
+    #[test]
+    fn test_check_status_to_bit_pending() {
+        let status = CheckStatus {
+            state: CheckState::Pending,
+            total: 1,
+            passed: 0,
+            failed: 0,
+            pending: 1,
+        };
+        assert_eq!(check_status_to_bit(&status), StatusBit::Pending);
+    }
+
+    #[test]
+    fn test_check_status_to_bit_neutral() {
+        let status = CheckStatus {
+            state: CheckState::Neutral,
+            total: 0,
+            passed: 0,
+            failed: 0,
+            pending: 0,
+        };
+        assert_eq!(check_status_to_bit(&status), StatusBit::NotApplicable);
+    }
+
+    // === Approval to StatusBit tests ===
+
+    #[test]
+    fn test_approval_to_bit_approved() {
+        let pr = PullRequest::new_for_test(
+            1,
+            "feature",
+            "main",
+            "Test PR",
+            PullRequestStatus::Open,
+            false,
+            None,
+            vec![crate::api::PullRequestReview::new_for_test(
+                PullRequestReviewState::APPROVED,
+            )],
+        );
+        assert_eq!(approval_to_bit(&pr), StatusBit::Passed);
+    }
+
+    #[test]
+    fn test_approval_to_bit_pending() {
+        let pr = PullRequest::new_for_test(
+            1,
+            "feature",
+            "main",
+            "Test PR",
+            PullRequestStatus::Open,
+            false,
+            None,
+            vec![],
+        );
+        assert_eq!(approval_to_bit(&pr), StatusBit::Failed);
+    }
+
+    // === Mergeable to StatusBit tests ===
+
+    #[test]
+    fn test_mergeable_to_bit_true() {
+        assert_eq!(mergeable_to_bit(Some(true)), StatusBit::Passed);
+    }
+
+    #[test]
+    fn test_mergeable_to_bit_false() {
+        assert_eq!(mergeable_to_bit(Some(false)), StatusBit::Failed);
+    }
+
+    #[test]
+    fn test_mergeable_to_bit_unknown() {
+        assert_eq!(mergeable_to_bit(None), StatusBit::Pending);
+    }
+
+    // === Truncate title tests ===
+
+    #[test]
+    fn test_truncate_title_short() {
+        assert_eq!(truncate_title("Short title", 50), "Short title");
+    }
+
+    #[test]
+    fn test_truncate_title_exact() {
+        let title = "x".repeat(50);
+        assert_eq!(truncate_title(&title, 50), title);
+    }
+
+    #[test]
+    fn test_truncate_title_long() {
+        let title = "x".repeat(60);
+        let result = truncate_title(&title, 50);
+        assert_eq!(result.len(), 50);
+        assert!(result.ends_with("..."));
+    }
+
+    #[test]
+    fn test_truncate_title_unicode() {
+        let title = "Add 日本語 support for the feature system here";
+        let result = truncate_title(title, 20);
+        assert!(result.chars().count() <= 20);
+        assert!(result.ends_with("..."));
+    }
+
+    // === Format status bits tests ===
+
+    #[test]
+    fn test_format_status_bits_unicode_all_passed() {
+        let status = PrStatus {
+            ci: StatusBit::Passed,
+            approved: StatusBit::Passed,
+            mergeable: StatusBit::Passed,
+            stack_clear: StatusBit::Passed,
+        };
+        assert_eq!(format_status_bits(&status, true), "[✓ ✓ ✓ ✓]");
+    }
+
+    #[test]
+    fn test_format_status_bits_unicode_mixed() {
+        let status = PrStatus {
+            ci: StatusBit::Pending,
+            approved: StatusBit::Failed,
+            mergeable: StatusBit::Passed,
+            stack_clear: StatusBit::Failed,
+        };
+        assert_eq!(format_status_bits(&status, true), "[⏳ ✗ ✓ ✗]");
+    }
+
+    #[test]
+    fn test_format_status_bits_ascii_all_passed() {
+        let status = PrStatus {
+            ci: StatusBit::Passed,
+            approved: StatusBit::Passed,
+            mergeable: StatusBit::Passed,
+            stack_clear: StatusBit::Passed,
+        };
+        assert_eq!(format_status_bits(&status, false), "[Y Y Y Y]");
+    }
+
+    #[test]
+    fn test_format_status_bits_ascii_mixed() {
+        let status = PrStatus {
+            ci: StatusBit::Pending,
+            approved: StatusBit::Failed,
+            mergeable: StatusBit::Passed,
+            stack_clear: StatusBit::Failed,
+        };
+        assert_eq!(format_status_bits(&status, false), "[? N Y N]");
+    }
+
+    #[test]
+    fn test_format_status_bits_with_na() {
+        let status = PrStatus {
+            ci: StatusBit::Passed,
+            approved: StatusBit::NotApplicable,
+            mergeable: StatusBit::Passed,
+            stack_clear: StatusBit::Passed,
+        };
+        assert_eq!(format_status_bits(&status, true), "[✓ ─ ✓ ✓]");
+        assert_eq!(format_status_bits(&status, false), "[Y - Y Y]");
+    }
+
+    // === Stack clear computation tests ===
+
+    fn make_status_entry(
+        branch: &str,
+        is_draft: bool,
+        is_trunk: bool,
+        approved: StatusBit,
+    ) -> StatusEntry {
+        StatusEntry {
+            branch: branch.to_string(),
+            pr_number: Some(1),
+            title: Some("Test".to_string()),
+            is_current: false,
+            is_draft,
+            is_trunk,
+            status: Some(PrStatus {
+                ci: StatusBit::Passed,
+                approved,
+                mergeable: StatusBit::Passed,
+                stack_clear: StatusBit::Pending,
+            }),
+            updated_at: None,
+            commits: vec![],
+            extra_commits: 0,
+        }
+    }
+
+    #[test]
+    fn test_compute_stack_clear_all_approved() {
+        let entries = vec![
+            make_status_entry("feature-3", false, false, StatusBit::Passed),
+            make_status_entry("feature-2", false, false, StatusBit::Passed),
+            make_status_entry("feature-1", false, false, StatusBit::Passed),
+            StatusEntry {
+                branch: "main".to_string(),
+                pr_number: None,
+                title: None,
+                is_current: false,
+                is_draft: false,
+                is_trunk: true,
+                status: None,
+                updated_at: None,
+                commits: vec![],
+                extra_commits: 0,
+            },
+        ];
+
+        assert_eq!(compute_stack_clear(&entries, 0), StatusBit::Passed);
+        assert_eq!(compute_stack_clear(&entries, 1), StatusBit::Passed);
+        assert_eq!(compute_stack_clear(&entries, 2), StatusBit::Passed);
+    }
+
+    #[test]
+    fn test_compute_stack_clear_blocked_by_draft() {
+        let entries = vec![
+            make_status_entry("feature-2", false, false, StatusBit::Passed),
+            make_status_entry("feature-1", true, false, StatusBit::Passed), // draft
+            StatusEntry {
+                branch: "main".to_string(),
+                pr_number: None,
+                title: None,
+                is_current: false,
+                is_draft: false,
+                is_trunk: true,
+                status: None,
+                updated_at: None,
+                commits: vec![],
+                extra_commits: 0,
+            },
+        ];
+
+        assert_eq!(compute_stack_clear(&entries, 0), StatusBit::Failed); // blocked by draft below
+        assert_eq!(compute_stack_clear(&entries, 1), StatusBit::Failed); // is draft
+    }
+
+    #[test]
+    fn test_compute_stack_clear_blocked_by_unapproved() {
+        let entries = vec![
+            make_status_entry("feature-2", false, false, StatusBit::Passed),
+            make_status_entry("feature-1", false, false, StatusBit::Failed), // not approved
+            StatusEntry {
+                branch: "main".to_string(),
+                pr_number: None,
+                title: None,
+                is_current: false,
+                is_draft: false,
+                is_trunk: true,
+                status: None,
+                updated_at: None,
+                commits: vec![],
+                extra_commits: 0,
+            },
+        ];
+
+        assert_eq!(compute_stack_clear(&entries, 0), StatusBit::Failed); // blocked
+        assert_eq!(compute_stack_clear(&entries, 1), StatusBit::Failed); // not approved
+    }
+
+    #[test]
+    fn test_compute_stack_clear_single_pr() {
+        let entries = vec![
+            make_status_entry("feature-1", false, false, StatusBit::Passed),
+            StatusEntry {
+                branch: "main".to_string(),
+                pr_number: None,
+                title: None,
+                is_current: false,
+                is_draft: false,
+                is_trunk: true,
+                status: None,
+                updated_at: None,
+                commits: vec![],
+                extra_commits: 0,
+            },
+        ];
+
+        assert_eq!(compute_stack_clear(&entries, 0), StatusBit::Passed);
+    }
+
+    // === Legend file tests with temp directory ===
+
+    fn with_temp_home<F>(test_fn: F)
+    where
+        F: FnOnce(&std::path::Path),
+    {
+        let temp_dir = TempDir::new().unwrap();
+        let original_home = std::env::var("HOME").ok();
+
+        // Override HOME for test
+        std::env::set_var("HOME", temp_dir.path());
+
+        test_fn(temp_dir.path());
+
+        // Restore original HOME
+        if let Some(home) = original_home {
+            std::env::set_var("HOME", home);
+        } else {
+            std::env::remove_var("HOME");
+        }
+        // TempDir automatically cleaned up on drop
+    }
+
+    #[test]
+    fn test_should_show_legend_first_run() {
+        with_temp_home(|_| {
+            // First call should return true and create the file
+            assert!(should_show_legend());
+        });
+    }
+
+    #[test]
+    fn test_should_show_legend_subsequent_run() {
+        with_temp_home(|home| {
+            // Create the legend file
+            let legend_path = home.join(LEGEND_FILE_NAME);
+            std::fs::write(&legend_path, "1").unwrap();
+
+            // Should return false now
+            assert!(!should_show_legend());
+        });
+    }
+
+    // === JSON output tests ===
+
+    #[test]
+    fn test_json_output_structure() {
+        let entries = vec![
+            StatusEntry {
+                branch: "feature".to_string(),
+                pr_number: Some(123),
+                title: Some("Test PR".to_string()),
+                is_current: true,
+                is_draft: false,
+                is_trunk: false,
+                status: Some(PrStatus {
+                    ci: StatusBit::Passed,
+                    approved: StatusBit::Passed,
+                    mergeable: StatusBit::Passed,
+                    stack_clear: StatusBit::Passed,
+                }),
+                updated_at: None,
+                commits: vec![],
+                extra_commits: 0,
+            },
+            StatusEntry {
+                branch: "main".to_string(),
+                pr_number: None,
+                title: None,
+                is_current: false,
+                is_draft: false,
+                is_trunk: true,
+                status: None,
+                updated_at: None,
+                commits: vec![],
+                extra_commits: 0,
+            },
+        ];
+
+        let json = render_status_json(&entries).unwrap();
+        assert!(json.contains("\"trunk\": \"main\""));
+        assert!(json.contains("\"branch\": \"feature\""));
+        assert!(json.contains("\"pr_number\": 123"));
+    }
+
+    #[test]
+    fn test_json_output_status_values() {
+        let entries = vec![StatusEntry {
+            branch: "feature".to_string(),
+            pr_number: Some(1),
+            title: Some("Test".to_string()),
+            is_current: false,
+            is_draft: false,
+            is_trunk: false,
+            status: Some(PrStatus {
+                ci: StatusBit::Passed,
+                approved: StatusBit::Failed,
+                mergeable: StatusBit::Pending,
+                stack_clear: StatusBit::NotApplicable,
+            }),
+            updated_at: None,
+            commits: vec![],
+            extra_commits: 0,
+        }];
+
+        let json = render_status_json(&entries).unwrap();
+        assert!(json.contains("\"ci\": \"passed\""));
+        assert!(json.contains("\"approved\": \"failed\""));
+        assert!(json.contains("\"mergeable\": \"pending\""));
+        assert!(json.contains("\"stack_clear\": \"n/a\""));
+    }
+
+    #[test]
+    fn test_json_output_pretty_formatted() {
+        let entries = vec![StatusEntry {
+            branch: "feature".to_string(),
+            pr_number: Some(1),
+            title: Some("Test".to_string()),
+            is_current: false,
+            is_draft: false,
+            is_trunk: false,
+            status: None,
+            updated_at: None,
+            commits: vec![],
+            extra_commits: 0,
+        }];
+
+        let json = render_status_json(&entries).unwrap();
+        // Pretty-printed JSON has newlines
+        assert!(json.contains('\n'));
+    }
+
+    // === Snapshot tests ===
+
+    fn make_test_entry(
+        branch: &str,
+        pr_number: Option<usize>,
+        title: Option<&str>,
+        is_current: bool,
+        is_draft: bool,
+        is_trunk: bool,
+        status: Option<PrStatus>,
+    ) -> StatusEntry {
+        StatusEntry {
+            branch: branch.to_string(),
+            pr_number,
+            title: title.map(String::from),
+            is_current,
+            is_draft,
+            is_trunk,
+            status,
+            updated_at: None,
+            commits: vec![],
+            extra_commits: 0,
+        }
+    }
+
+    #[test]
+    fn test_snapshot_status_all_passing() {
+        let config = StatusConfig {
+            use_color: false,
+            use_unicode: false,
+            show_legend: false,
+            include_checks: true,
+            json_output: false,
+        };
+
+        let entries = vec![
+            make_test_entry(
+                "feature-2",
+                Some(124),
+                Some("Add new feature"),
+                true,
+                false,
+                false,
+                Some(PrStatus {
+                    ci: StatusBit::Passed,
+                    approved: StatusBit::Passed,
+                    mergeable: StatusBit::Passed,
+                    stack_clear: StatusBit::Passed,
+                }),
+            ),
+            make_test_entry(
+                "feature-1",
+                Some(123),
+                Some("Setup base"),
+                false,
+                false,
+                false,
+                Some(PrStatus {
+                    ci: StatusBit::Passed,
+                    approved: StatusBit::Passed,
+                    mergeable: StatusBit::Passed,
+                    stack_clear: StatusBit::Passed,
+                }),
+            ),
+            make_test_entry("main", None, None, false, false, true, None),
+        ];
+
+        let output = render_status(&entries, &config, true);
+        insta::assert_snapshot!(output);
+    }
+
+    #[test]
+    fn test_snapshot_status_mixed() {
+        let config = StatusConfig {
+            use_color: false,
+            use_unicode: false,
+            show_legend: false,
+            include_checks: true,
+            json_output: false,
+        };
+
+        let entries = vec![
+            make_test_entry(
+                "feature-2",
+                Some(124),
+                Some("Add new feature"),
+                true,
+                false,
+                false,
+                Some(PrStatus {
+                    ci: StatusBit::Pending,
+                    approved: StatusBit::Failed,
+                    mergeable: StatusBit::Passed,
+                    stack_clear: StatusBit::Failed,
+                }),
+            ),
+            make_test_entry(
+                "feature-1",
+                Some(123),
+                Some("Setup base"),
+                false,
+                false,
+                false,
+                Some(PrStatus {
+                    ci: StatusBit::Passed,
+                    approved: StatusBit::Passed,
+                    mergeable: StatusBit::Failed,
+                    stack_clear: StatusBit::Passed,
+                }),
+            ),
+            make_test_entry("main", None, None, false, false, true, None),
+        ];
+
+        let output = render_status(&entries, &config, true);
+        insta::assert_snapshot!(output);
+    }
+
+    #[test]
+    fn test_snapshot_status_with_draft() {
+        let config = StatusConfig {
+            use_color: false,
+            use_unicode: false,
+            show_legend: false,
+            include_checks: true,
+            json_output: false,
+        };
+
+        let entries = vec![
+            make_test_entry(
+                "wip-feature",
+                Some(125),
+                Some("Work in progress"),
+                true,
+                true, // draft
+                false,
+                Some(PrStatus {
+                    ci: StatusBit::Pending,
+                    approved: StatusBit::Failed,
+                    mergeable: StatusBit::Passed,
+                    stack_clear: StatusBit::Failed,
+                }),
+            ),
+            make_test_entry(
+                "feature-1",
+                Some(123),
+                Some("Setup base"),
+                false,
+                false,
+                false,
+                Some(PrStatus {
+                    ci: StatusBit::Passed,
+                    approved: StatusBit::Passed,
+                    mergeable: StatusBit::Passed,
+                    stack_clear: StatusBit::Passed,
+                }),
+            ),
+            make_test_entry("main", None, None, false, false, true, None),
+        ];
+
+        let output = render_status(&entries, &config, true);
+        insta::assert_snapshot!(output);
+    }
+
+    #[test]
+    fn test_snapshot_status_no_checks() {
+        let config = StatusConfig {
+            use_color: false,
+            use_unicode: false,
+            show_legend: false,
+            include_checks: false, // no checks
+            json_output: false,
+        };
+
+        let entries = vec![
+            make_test_entry(
+                "feature-2",
+                Some(124),
+                Some("Add new feature"),
+                true,
+                false,
+                false,
+                None, // no status
+            ),
+            make_test_entry(
+                "feature-1",
+                Some(123),
+                Some("Setup base"),
+                false,
+                false,
+                false,
+                None,
+            ),
+            make_test_entry("main", None, None, false, false, true, None),
+        ];
+
+        let output = render_status(&entries, &config, true);
+        insta::assert_snapshot!(output);
+    }
+
+    #[test]
+    fn test_snapshot_status_with_commits() {
+        let config = StatusConfig {
+            use_color: false,
+            use_unicode: false,
+            show_legend: false,
+            include_checks: true,
+            json_output: false,
+        };
+
+        let entries = vec![
+            StatusEntry {
+                branch: "feature-1".to_string(),
+                pr_number: Some(123),
+                title: Some("Add feature".to_string()),
+                is_current: true,
+                is_draft: false,
+                is_trunk: false,
+                status: Some(PrStatus {
+                    ci: StatusBit::Passed,
+                    approved: StatusBit::Passed,
+                    mergeable: StatusBit::Passed,
+                    stack_clear: StatusBit::Passed,
+                }),
+                updated_at: None,
+                commits: vec![
+                    CommitInfo {
+                        sha: "abc1234".to_string(),
+                        message: "Add widget component".to_string(),
+                    },
+                    CommitInfo {
+                        sha: "def5678".to_string(),
+                        message: "Update styles".to_string(),
+                    },
+                ],
+                extra_commits: 2,
+            },
+            make_test_entry("main", None, None, false, false, true, None),
+        ];
+
+        let output = render_status(&entries, &config, true);
+        insta::assert_snapshot!(output);
+    }
+
+    #[test]
+    fn test_snapshot_status_with_legend() {
+        let config = StatusConfig {
+            use_color: false,
+            use_unicode: false,
+            show_legend: true, // show legend
+            include_checks: true,
+            json_output: false,
+        };
+
+        let entries = vec![
+            make_test_entry(
+                "feature-1",
+                Some(123),
+                Some("Add feature"),
+                false,
+                false,
+                false,
+                Some(PrStatus {
+                    ci: StatusBit::Passed,
+                    approved: StatusBit::Passed,
+                    mergeable: StatusBit::Passed,
+                    stack_clear: StatusBit::Passed,
+                }),
+            ),
+            make_test_entry("main", None, None, false, false, true, None),
+        ];
+
+        let output = render_status(&entries, &config, true);
+        insta::assert_snapshot!(output);
+    }
+
+    #[test]
+    fn test_snapshot_status_unicode() {
+        let config = StatusConfig {
+            use_color: false,
+            use_unicode: true, // unicode
+            show_legend: false,
+            include_checks: true,
+            json_output: false,
+        };
+
+        let entries = vec![
+            make_test_entry(
+                "feature-1",
+                Some(123),
+                Some("Add feature"),
+                true,
+                false,
+                false,
+                Some(PrStatus {
+                    ci: StatusBit::Passed,
+                    approved: StatusBit::Failed,
+                    mergeable: StatusBit::Pending,
+                    stack_clear: StatusBit::NotApplicable,
+                }),
+            ),
+            make_test_entry("main", None, None, false, false, true, None),
+        ];
+
+        let output = render_status(&entries, &config, true);
+        insta::assert_snapshot!(output);
+    }
+
+    #[test]
+    fn test_snapshot_status_json() {
+        let entries = vec![
+            StatusEntry {
+                branch: "feature-1".to_string(),
+                pr_number: Some(123),
+                title: Some("Add feature".to_string()),
+                is_current: true,
+                is_draft: false,
+                is_trunk: false,
+                status: Some(PrStatus {
+                    ci: StatusBit::Passed,
+                    approved: StatusBit::Passed,
+                    mergeable: StatusBit::Passed,
+                    stack_clear: StatusBit::Passed,
+                }),
+                updated_at: Some("2024-01-15T10:30:00Z".to_string()),
+                commits: vec![CommitInfo {
+                    sha: "abc1234".to_string(),
+                    message: "Add widget".to_string(),
+                }],
+                extra_commits: 0,
+            },
+            StatusEntry {
+                branch: "main".to_string(),
+                pr_number: None,
+                title: None,
+                is_current: false,
+                is_draft: false,
+                is_trunk: true,
+                status: None,
+                updated_at: None,
+                commits: vec![],
+                extra_commits: 0,
+            },
+        ];
+
+        let output = render_status_json(&entries).unwrap();
+        insta::assert_snapshot!(output);
+    }
+
+    #[test]
+    fn test_snapshot_status_single_pr() {
+        let config = StatusConfig {
+            use_color: false,
+            use_unicode: false,
+            show_legend: false,
+            include_checks: true,
+            json_output: false,
+        };
+
+        let entries = vec![
+            make_test_entry(
+                "feature-1",
+                Some(123),
+                Some("Single PR"),
+                false,
+                false,
+                false,
+                Some(PrStatus {
+                    ci: StatusBit::Passed,
+                    approved: StatusBit::Passed,
+                    mergeable: StatusBit::Passed,
+                    stack_clear: StatusBit::Passed,
+                }),
+            ),
+            make_test_entry("main", None, None, false, false, true, None),
+        ];
+
+        let output = render_status(&entries, &config, true);
+        insta::assert_snapshot!(output);
+    }
+}

--- a/src/tree.rs
+++ b/src/tree.rs
@@ -55,7 +55,7 @@ pub enum PrState {
 }
 
 /// Information about a single commit
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, serde::Serialize)]
 pub struct CommitInfo {
     pub sha: String,
     pub message: String,


### PR DESCRIPTION
## Summary

Add comprehensive documentation for the status command:

- Usage examples
- Status bits explanation (CI, Approved, Mergeable, Stack clear)
- Flag descriptions  
- Output format examples (Unicode, ASCII, JSON)
- Legend behavior
- Integration with `log --status`

## Documentation

See `docs/status.md` for the full documentation.

---
*Part 5 of 5 in the status-command stack*
<!---GHSTACKOPEN-->
### Stacked PR Chain: status-command
| PR | Title | Merges Into |
|:--:|:------|:-----------:|
|#30|Add head_sha/html_url accessors to PullRequest|-|
|#31|Add GitHub Checks API module|#30|
|#32|Add status module with core logic and rendering|#31|
|#33|Add status subcommand and log --status flag|#32|
|#34|👉Add status command documentation|#33|
<!---GHSTACKCLOSE-->
