### PR TITLE
[smart-log] feat: make log and status identifier optional with branch inference

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -142,13 +142,44 @@ fn clap<'a, 'b>() -> App<'a, 'b> {
                 .help("Show status bits (CI, approval, conflicts, stack health)"),
         );
 
+    // For status command, identifier is optional (can infer from branch)
+    let status_identifier = Arg::with_name("identifier")
+        .index(1)
+        .required(false)
+        .help("Stack identifier in PR titles (optional - infers from current branch if omitted)");
+
     let status_cmd = SubCommand::with_name("status")
         .about("Show stack status with CI, approval, and merge readiness indicators")
-        .setting(AppSettings::ArgRequiredElseHelp)
-        .arg(identifier.clone())
+        .arg(status_identifier)
         .arg(exclude.clone())
         .arg(repository.clone())
         .arg(origin.clone())
+        .arg(
+            Arg::with_name("branch")
+                .long("branch")
+                .short("b")
+                .takes_value(true)
+                .help("Infer stack from this branch instead of current branch"),
+        )
+        .arg(
+            Arg::with_name("all")
+                .long("all")
+                .short("a")
+                .takes_value(false)
+                .help("List all detected stacks and select interactively"),
+        )
+        .arg(
+            Arg::with_name("ci")
+                .long("ci")
+                .takes_value(false)
+                .help("Non-interactive mode for CI (requires identifier or --branch)"),
+        )
+        .arg(
+            Arg::with_name("trunk")
+                .long("trunk")
+                .takes_value(true)
+                .help("Trunk branch name (default: auto-detect or 'main')"),
+        )
         .arg(
             Arg::with_name("project")
                 .long("project")
@@ -854,33 +885,232 @@ async fn main() -> Result<(), Box<dyn Error>> {
         }
 
         ("status", Some(m)) => {
-            let identifier = m.value_of("identifier").unwrap();
+            let explicit_identifier = m.value_of("identifier");
+            let branch_override = m.value_of("branch");
+            let show_all = m.is_present("all");
+            let ci_mode = m.is_present("ci");
+            let json_output = m.is_present("json");
 
-            // resolve repository with fallback chain
+            // Resolve trunk branch
+            let trunk = m
+                .value_of("trunk")
+                .map(String::from)
+                .or_else(identifier::detect_trunk_branch)
+                .unwrap_or_else(|| "main".to_string());
+
+            // Resolve repository with fallback chain
             let remote_name = m.value_of("origin").unwrap_or("origin");
             let repository = resolve_repository(m.value_of("repository"), &repository, remote_name)
                 .unwrap_or_else(|e| panic!("{}", e));
 
-            let json_output = m.is_present("json");
+            // Determine how to find the stack
+            let stack: FlatDep = if let Some(id) = explicit_identifier {
+                // === EXISTING BEHAVIOR: Search by identifier ===
+                if !json_output {
+                    println!(
+                        "Searching for {} identifier in {} repo",
+                        style(id).bold(),
+                        style(&repository).bold()
+                    );
+                }
+                build_pr_stack_for_repo(id, &repository, &credentials, get_excluded(m)).await?
+            } else if show_all {
+                // === NEW: --all flag - show all stacks ===
+                if ci_mode {
+                    eprintln!(
+                        "{} --all requires interactive mode (incompatible with --ci)",
+                        style("Error:").red().bold()
+                    );
+                    std::process::exit(1);
+                }
 
-            if !json_output {
-                println!(
-                    "Searching for {} identifier in {} repo",
-                    style(identifier).bold(),
-                    style(&repository).bold()
-                );
-            }
+                if !json_output {
+                    println!("Discovering stacks in {}...", style(&repository).bold());
+                }
 
-            let stack =
-                build_pr_stack_for_repo(identifier, &repository, &credentials, get_excluded(m))
-                    .await?;
+                let stacks =
+                    api::stack::discover_all_stacks(&repository, &trunk, &credentials).await?;
+
+                if stacks.is_empty() {
+                    if json_output {
+                        println!(r#"{{"stack": [], "trunk": "{}"}}"#, trunk);
+                    } else {
+                        println!("No open stacks found.");
+                    }
+                    return Ok(());
+                }
+
+                let summaries: Vec<StackSummary> = stacks
+                    .iter()
+                    .map(|s| StackSummary::from_prs(s, &trunk))
+                    .collect();
+
+                let selected = identifier::prompt_select_stack(&summaries)?;
+
+                // Convert selected stack to FlatDep
+                let prs: Vec<Rc<PullRequest>> =
+                    stacks[selected].iter().cloned().map(Rc::new).collect();
+                let g = graph::build(&prs);
+                graph::log(&g)
+            } else {
+                // === NEW: Infer from current/specified branch ===
+                let repo_handle = m
+                    .value_of("project")
+                    .and_then(|p| Repository::open(p).ok())
+                    .or_else(tree::detect_repo);
+
+                let branch = branch_override
+                    .map(String::from)
+                    .or_else(|| repo_handle.as_ref().and_then(tree::current_branch));
+
+                match branch {
+                    Some(branch) => {
+                        // Check if on trunk
+                        if identifier::is_trunk_branch(&branch, Some(&trunk)) {
+                            if ci_mode {
+                                eprintln!(
+                                    "{} On trunk branch '{}'. Provide an identifier or use --branch.",
+                                    style("Error:").red().bold(),
+                                    branch
+                                );
+                                std::process::exit(1);
+                            }
+
+                            if !json_output {
+                                println!("You're on '{}' (trunk branch).\n", style(&branch).cyan());
+                            }
+
+                            // Discover all stacks for selection
+                            let stacks =
+                                api::stack::discover_all_stacks(&repository, &trunk, &credentials)
+                                    .await?;
+
+                            let summaries: Vec<StackSummary> = stacks
+                                .iter()
+                                .map(|s| StackSummary::from_prs(s, &trunk))
+                                .collect();
+
+                            match identifier::prompt_trunk_action(&summaries)? {
+                                TrunkAction::EnterIdentifier(id) => {
+                                    if !json_output {
+                                        println!(
+                                            "\nSearching for {} identifier in {} repo",
+                                            style(&id).bold(),
+                                            style(&repository).bold()
+                                        );
+                                    }
+                                    build_pr_stack_for_repo(
+                                        &id,
+                                        &repository,
+                                        &credentials,
+                                        get_excluded(m),
+                                    )
+                                    .await?
+                                }
+                                TrunkAction::SelectStack(idx) => {
+                                    let prs: Vec<Rc<PullRequest>> =
+                                        stacks[idx].iter().cloned().map(Rc::new).collect();
+                                    let g = graph::build(&prs);
+                                    graph::log(&g)
+                                }
+                                TrunkAction::Cancel => {
+                                    return Ok(());
+                                }
+                            }
+                        } else {
+                            // Discover stack from branch
+                            if !json_output {
+                                println!(
+                                    "Discovering stack for branch '{}'...",
+                                    style(&branch).cyan()
+                                );
+                            }
+
+                            match api::stack::fetch_pr_by_head(&repository, &branch, &credentials)
+                                .await?
+                            {
+                                Some(pr) => {
+                                    let prs = api::stack::discover_stack(
+                                        &repository,
+                                        pr,
+                                        &trunk,
+                                        &credentials,
+                                    )
+                                    .await?;
+                                    let prs: Vec<Rc<PullRequest>> =
+                                        prs.into_iter().map(Rc::new).collect();
+                                    let g = graph::build(&prs);
+                                    graph::log(&g)
+                                }
+                                None => {
+                                    // No PR found for this branch
+                                    if ci_mode || json_output {
+                                        if json_output {
+                                            println!(
+                                                r#"{{"error": "No PR found for branch '{}'", "stack": [], "trunk": "{}"}}"#,
+                                                branch, trunk
+                                            );
+                                        } else {
+                                            eprintln!(
+                                                "{} No PR found for branch '{}'",
+                                                style("Error:").red().bold(),
+                                                branch
+                                            );
+                                        }
+                                        std::process::exit(1);
+                                    }
+
+                                    // Interactive: suggest creating PR
+                                    gh_cli::suggest_create_pr(&branch, &trunk);
+                                    return Ok(());
+                                }
+                            }
+                        }
+                    }
+                    None => {
+                        // Could not determine branch
+                        if ci_mode || json_output {
+                            if json_output {
+                                println!(
+                                    r#"{{"error": "Could not determine current branch", "stack": [], "trunk": "{}"}}"#,
+                                    trunk
+                                );
+                            } else {
+                                eprintln!(
+                                    "{} Could not determine current branch. Provide identifier or --branch.",
+                                    style("Error:").red().bold()
+                                );
+                            }
+                            std::process::exit(1);
+                        }
+
+                        eprintln!(
+                            "{} Could not determine current branch.\n",
+                            style("Note:").yellow()
+                        );
+                        eprintln!("You can:");
+                        eprintln!("  - Run from inside a git repository");
+                        eprintln!(
+                            "  - Use {} to specify a branch",
+                            style("--branch <name>").cyan()
+                        );
+                        eprintln!(
+                            "  - Provide an identifier directly: {}",
+                            style("gh-stack status 'STACK-ID'").cyan()
+                        );
+                        return Ok(());
+                    }
+                }
+            };
 
             // Check for empty stack
             if stack.is_empty() {
                 if json_output {
-                    println!(r#"{{"stack": [], "trunk": "main"}}"#);
+                    println!(r#"{{"stack": [], "trunk": "{}"}}"#, trunk);
+                } else if let Some(id) = explicit_identifier {
+                    println!("No PRs found matching '{}'", id);
                 } else {
-                    println!("No PRs found matching '{}'", identifier);
+                    println!("No PRs found in stack.");
                 }
                 return Ok(());
             }


### PR DESCRIPTION
## Summary

Enable `gh-stack log` and `gh-stack status` to work without an explicit identifier by inferring the stack from the current branch's PR chain.

## New Usage

```bash
# Infer stack from current branch (NEW)
gh-stack log
gh-stack status

# Infer from specific branch (NEW)
gh-stack log --branch feat/my-feature
gh-stack status --branch feat/my-feature

# List all stacks, select interactively (NEW)
gh-stack log --all
gh-stack status --all

# CI mode - requires identifier or --branch (NEW)
gh-stack log --branch $GITHUB_HEAD_REF --ci
gh-stack status --branch $GITHUB_HEAD_REF --ci --json

# Existing behavior still works
gh-stack log 'STACK-ID'
gh-stack status 'STACK-ID'
```

## Changes

**Modified: `src/main.rs`**

New CLI arguments for `log` and `status` commands:
- `--branch, -b` - Infer stack from specified branch instead of current
- `--all, -a` - List all stacks and select interactively
- `--ci` - Non-interactive mode for CI environments
- `--trunk` - Override trunk branch detection (default: auto-detect or "main")

Behavior changes:
- Running `gh-stack log` or `gh-stack status` without args infers from current branch
- On trunk branch: prompts to enter identifier or select stack
- No PR found: suggests `gh pr create` command with install hints
- CI mode requires explicit identifier or `--branch` flag (fails otherwise)
- JSON output mode handles errors gracefully with error field in response

## Backwards Compatibility

The identifier argument is now optional but still fully supported. Existing scripts using `gh-stack log 'STACK-ID'` or `gh-stack status 'STACK-ID'` will continue to work unchanged.





<!---GHSTACKOPEN-->
### Stacked PR Chain: smart-log
| PR | Title | Merges Into |
|:--:|:------|:-----------:|
|#35|feat: add stack discovery API|-|
|#36|feat: add rate limit retry logic|#35|
|#37|feat: add identifier detection and prompts|#36|
|#38|feat: add gh CLI helpers|#37|
|#39|👉feat: make log and status identifier optional with branch inference|#38|
|#40|docs: update log and status documentation for smart defaults|#39|
|#41|perf: optimize stack discovery with batch fetch|#40|
|#42|perf: parallelize status check fetches|#41|
<!---GHSTACKCLOSE-->



