### PR TITLE
[smart-log] perf: optimize stack discovery with batch fetch

### DIFF
--- a/src/api/stack.rs
+++ b/src/api/stack.rs
@@ -2,6 +2,12 @@
 //!
 //! Walks PR base/head chains to discover full stack structure without
 //! requiring identifier patterns in PR titles.
+//!
+//! ## Performance
+//!
+//! Stack discovery uses a batch-fetch strategy: all open PRs are fetched
+//! in a single paginated API call, then the chain is walked in-memory.
+//! This reduces API calls from O(N) to O(1) for most repositories.
 
 use crate::api::{github_api_base, PullRequest};
 use crate::Credentials;
@@ -9,6 +15,9 @@ use reqwest::Client;
 use std::collections::{HashMap, HashSet};
 use std::error::Error;
 use std::time::Duration;
+
+/// Maximum number of pages to fetch (100 PRs per page = 1000 PRs max)
+const MAX_PAGES: u32 = 10;
 
 /// Build a GET request with auth headers
 fn build_request(client: &Client, creds: &Credentials, url: &str) -> reqwest::RequestBuilder {
@@ -18,6 +27,45 @@ fn build_request(client: &Client, creds: &Credentials, url: &str) -> reqwest::Re
         .header("Authorization", format!("token {}", creds.token))
         .header("User-Agent", "luqven/gh-stack")
         .header("Accept", "application/vnd.github.v3+json")
+}
+
+/// Index of PRs for fast lookup by head/base branch.
+///
+/// Built once from a batch fetch, then used for in-memory chain walking.
+struct PrIndex {
+    by_head: HashMap<String, PullRequest>,
+    by_base: HashMap<String, Vec<PullRequest>>,
+}
+
+impl PrIndex {
+    /// Build an index from a list of PRs
+    fn from_prs(prs: Vec<PullRequest>) -> Self {
+        let mut by_head = HashMap::new();
+        let mut by_base: HashMap<String, Vec<PullRequest>> = HashMap::new();
+
+        for pr in prs {
+            by_base
+                .entry(pr.base().to_string())
+                .or_default()
+                .push(pr.clone());
+            by_head.insert(pr.head().to_string(), pr);
+        }
+
+        Self { by_head, by_base }
+    }
+
+    /// Get a PR by its head branch name
+    fn get_by_head(&self, head: &str) -> Option<&PullRequest> {
+        self.by_head.get(head)
+    }
+
+    /// Get all PRs that target a given base branch
+    fn get_by_base(&self, base: &str) -> Vec<&PullRequest> {
+        self.by_base
+            .get(base)
+            .map(|v| v.iter().collect())
+            .unwrap_or_default()
+    }
 }
 
 /// Fetch a PR by its head branch name.
@@ -97,7 +145,10 @@ pub async fn fetch_prs_by_base(
     Ok(prs)
 }
 
-/// Fetch all open PRs in a repository.
+/// Fetch all open PRs in a repository with pagination support.
+///
+/// Fetches up to MAX_PAGES pages (1000 PRs) to support enterprise users
+/// with large numbers of open PRs.
 ///
 /// # Arguments
 /// * `repo` - Repository in "owner/repo" format
@@ -107,34 +158,45 @@ pub async fn fetch_all_open_prs(
     creds: &Credentials,
 ) -> Result<Vec<PullRequest>, Box<dyn Error>> {
     let client = Client::new();
+    let mut all_prs = Vec::new();
 
-    // Fetch up to 100 open PRs (pagination could be added for larger repos)
-    let url = format!(
-        "{}/repos/{}/pulls?state=open&per_page=100",
-        github_api_base(),
-        repo
-    );
+    for page in 1..=MAX_PAGES {
+        let url = format!(
+            "{}/repos/{}/pulls?state=open&per_page=100&page={}",
+            github_api_base(),
+            repo,
+            page
+        );
 
-    let response = build_request(&client, creds, &url).send().await?;
+        let response = build_request(&client, creds, &url).send().await?;
 
-    if response.status() == 429 {
-        return Err("GitHub API rate limit exceeded".into());
+        if response.status() == 429 {
+            return Err("GitHub API rate limit exceeded".into());
+        }
+
+        if !response.status().is_success() {
+            let status = response.status();
+            let text = response.text().await.unwrap_or_default();
+            return Err(format!("Failed to fetch open PRs ({}): {}", status, text).into());
+        }
+
+        let prs: Vec<PullRequest> = response.json().await?;
+        let count = prs.len();
+        all_prs.extend(prs);
+
+        // GitHub returns fewer items when we've reached the end
+        if count < 100 {
+            break;
+        }
     }
 
-    if !response.status().is_success() {
-        let status = response.status();
-        let text = response.text().await.unwrap_or_default();
-        return Err(format!("Failed to fetch open PRs ({}): {}", status, text).into());
-    }
-
-    let prs: Vec<PullRequest> = response.json().await?;
-    Ok(prs)
+    Ok(all_prs)
 }
 
 /// Discover the full stack by walking PR chain from a starting PR.
 ///
-/// Walks UP via base branches (finding ancestors) and DOWN via child PRs
-/// (finding descendants) until the full connected stack is discovered.
+/// Uses batch-fetch strategy: fetches all open PRs in one paginated call,
+/// then walks the chain in-memory. This reduces API calls from O(N) to O(1).
 ///
 /// # Arguments
 /// * `repo` - Repository in "owner/repo" format
@@ -150,6 +212,25 @@ pub async fn discover_stack(
     trunk: &str,
     creds: &Credentials,
 ) -> Result<Vec<PullRequest>, Box<dyn Error>> {
+    // Batch fetch all open PRs (1 paginated API call)
+    let all_prs = fetch_all_open_prs(repo, creds).await?;
+
+    // Build in-memory index
+    let index = PrIndex::from_prs(all_prs);
+
+    // Walk chain in memory (no more API calls)
+    Ok(discover_stack_from_index(&index, starting_pr, trunk))
+}
+
+/// Walk stack using pre-fetched PR index (pure in-memory operation).
+///
+/// This is the core algorithm that walks up and down the PR chain
+/// without making any API calls.
+fn discover_stack_from_index(
+    index: &PrIndex,
+    starting_pr: PullRequest,
+    trunk: &str,
+) -> Vec<PullRequest> {
     let mut visited: HashMap<String, PullRequest> = HashMap::new();
     visited.insert(starting_pr.head().to_string(), starting_pr.clone());
 
@@ -164,10 +245,10 @@ pub async fn discover_stack(
         }
         seen_bases.insert(base.clone());
 
-        // Try to find a PR with this branch as its head
-        if let Some(pr) = fetch_pr_by_head(repo, &base, creds).await? {
+        // Try to find a PR with this branch as its head (in-memory lookup)
+        if let Some(pr) = index.get_by_head(&base) {
             let pr_base = pr.base().to_string();
-            visited.insert(pr.head().to_string(), pr);
+            visited.insert(pr.head().to_string(), pr.clone());
             up_queue.push(pr_base);
         }
     }
@@ -182,20 +263,18 @@ pub async fn discover_stack(
         }
         seen_heads.insert(head.clone());
 
-        // Find all PRs that target this branch as their base
-        let children = fetch_prs_by_base(repo, &head, creds).await?;
-        for child in children {
+        // Find all PRs that target this branch as their base (in-memory lookup)
+        for child in index.get_by_base(&head) {
             if !visited.contains_key(child.head()) {
                 let child_head = child.head().to_string();
-                visited.insert(child_head.clone(), child);
+                visited.insert(child_head.clone(), child.clone());
                 down_queue.push(child_head);
             }
         }
     }
 
     // Sort PRs by their position in the stack (bottom to top)
-    let prs: Vec<PullRequest> = visited.into_values().collect();
-    Ok(sort_stack(prs, trunk))
+    sort_stack(visited.into_values().collect(), trunk)
 }
 
 /// Sort PRs by their position in the stack (bottom to top).
@@ -261,7 +340,7 @@ fn sort_stack(prs: Vec<PullRequest>, trunk: &str) -> Vec<PullRequest> {
 /// Discover all stacks in a repository.
 ///
 /// Groups PRs by their root (PR whose base is trunk) and returns
-/// each group as a separate stack.
+/// each group as a separate stack. Uses batch-fetch for efficiency.
 ///
 /// # Arguments
 /// * `repo` - Repository in "owner/repo" format
@@ -276,14 +355,21 @@ pub async fn discover_all_stacks(
     creds: &Credentials,
 ) -> Result<Vec<Vec<PullRequest>>, Box<dyn Error>> {
     let all_prs = fetch_all_open_prs(repo, creds).await?;
+    Ok(group_into_stacks(all_prs, trunk))
+}
 
-    if all_prs.is_empty() {
-        return Ok(vec![]);
+/// Group PRs into stacks (pure in-memory operation).
+///
+/// PRs are grouped by walking from each root (PR whose base is trunk)
+/// down through child PRs.
+fn group_into_stacks(prs: Vec<PullRequest>, trunk: &str) -> Vec<Vec<PullRequest>> {
+    if prs.is_empty() {
+        return vec![];
     }
 
     // Build adjacency: base -> list of PRs targeting that base
     let mut base_to_prs: HashMap<String, Vec<&PullRequest>> = HashMap::new();
-    for pr in &all_prs {
+    for pr in &prs {
         base_to_prs
             .entry(pr.base().to_string())
             .or_default()
@@ -291,7 +377,7 @@ pub async fn discover_all_stacks(
     }
 
     // Find root PRs (those whose base is trunk)
-    let roots: Vec<&PullRequest> = all_prs.iter().filter(|pr| pr.base() == trunk).collect();
+    let roots: Vec<&PullRequest> = prs.iter().filter(|pr| pr.base() == trunk).collect();
 
     // For each root, build its stack by walking down
     let mut stacks = Vec::new();
@@ -327,7 +413,7 @@ pub async fn discover_all_stacks(
     // Sort stacks by size (largest first) for better UX
     stacks.sort_by_key(|s| std::cmp::Reverse(s.len()));
 
-    Ok(stacks)
+    stacks
 }
 
 #[cfg(test)]
@@ -354,6 +440,181 @@ mod tests {
             }}"#
         )
     }
+
+    fn make_test_pr(number: usize, head: &str, base: &str) -> PullRequest {
+        PullRequest::new_for_test(
+            number,
+            head,
+            base,
+            &format!("PR {}", number),
+            PullRequestStatus::Open,
+            false,
+            None,
+            vec![],
+        )
+    }
+
+    // === PrIndex tests ===
+
+    #[test]
+    fn test_pr_index_get_by_head() {
+        let pr1 = make_test_pr(1, "feature-1", "main");
+        let pr2 = make_test_pr(2, "feature-2", "feature-1");
+
+        let index = PrIndex::from_prs(vec![pr1, pr2]);
+
+        assert!(index.get_by_head("feature-1").is_some());
+        assert_eq!(index.get_by_head("feature-1").unwrap().number(), 1);
+        assert!(index.get_by_head("feature-2").is_some());
+        assert!(index.get_by_head("nonexistent").is_none());
+    }
+
+    #[test]
+    fn test_pr_index_get_by_base() {
+        let pr1 = make_test_pr(1, "feature-1", "main");
+        let pr2 = make_test_pr(2, "feature-2", "main");
+        let pr3 = make_test_pr(3, "feature-3", "feature-1");
+
+        let index = PrIndex::from_prs(vec![pr1, pr2, pr3]);
+
+        let main_children = index.get_by_base("main");
+        assert_eq!(main_children.len(), 2);
+
+        let feature1_children = index.get_by_base("feature-1");
+        assert_eq!(feature1_children.len(), 1);
+        assert_eq!(feature1_children[0].number(), 3);
+
+        let no_children = index.get_by_base("feature-3");
+        assert!(no_children.is_empty());
+    }
+
+    // === discover_stack_from_index tests ===
+
+    #[test]
+    fn test_discover_stack_from_index_linear() {
+        let pr1 = make_test_pr(1, "feature-1", "main");
+        let pr2 = make_test_pr(2, "feature-2", "feature-1");
+        let pr3 = make_test_pr(3, "feature-3", "feature-2");
+
+        let index = PrIndex::from_prs(vec![pr1.clone(), pr2, pr3]);
+
+        // Start from middle of stack
+        let stack = discover_stack_from_index(&index, pr1, "main");
+
+        assert_eq!(stack.len(), 3);
+        assert_eq!(stack[0].number(), 1); // bottom
+        assert_eq!(stack[1].number(), 2);
+        assert_eq!(stack[2].number(), 3); // top
+    }
+
+    #[test]
+    fn test_discover_stack_from_index_from_top() {
+        let pr1 = make_test_pr(1, "feature-1", "main");
+        let pr2 = make_test_pr(2, "feature-2", "feature-1");
+        let pr3 = make_test_pr(3, "feature-3", "feature-2");
+
+        let index = PrIndex::from_prs(vec![pr1, pr2, pr3.clone()]);
+
+        // Start from top of stack
+        let stack = discover_stack_from_index(&index, pr3, "main");
+
+        assert_eq!(stack.len(), 3);
+        assert_eq!(stack[0].number(), 1); // bottom
+        assert_eq!(stack[2].number(), 3); // top
+    }
+
+    #[test]
+    fn test_discover_stack_from_index_single_pr() {
+        let pr = make_test_pr(1, "feature", "main");
+        let index = PrIndex::from_prs(vec![pr.clone()]);
+
+        let stack = discover_stack_from_index(&index, pr, "main");
+
+        assert_eq!(stack.len(), 1);
+        assert_eq!(stack[0].number(), 1);
+    }
+
+    #[test]
+    fn test_discover_stack_from_index_unrelated_prs() {
+        // Two separate stacks - should only discover one
+        let pr1 = make_test_pr(1, "feature-1", "main");
+        let pr2 = make_test_pr(2, "other-stack", "main");
+
+        let index = PrIndex::from_prs(vec![pr1.clone(), pr2]);
+
+        let stack = discover_stack_from_index(&index, pr1, "main");
+
+        assert_eq!(stack.len(), 1);
+        assert_eq!(stack[0].number(), 1);
+    }
+
+    // === group_into_stacks tests ===
+
+    #[test]
+    fn test_group_into_stacks_single_stack() {
+        let pr1 = make_test_pr(1, "feature-1", "main");
+        let pr2 = make_test_pr(2, "feature-2", "feature-1");
+
+        let stacks = group_into_stacks(vec![pr1, pr2], "main");
+
+        assert_eq!(stacks.len(), 1);
+        assert_eq!(stacks[0].len(), 2);
+    }
+
+    #[test]
+    fn test_group_into_stacks_multiple_stacks() {
+        let pr1 = make_test_pr(1, "feature-1", "main");
+        let pr2 = make_test_pr(2, "feature-2", "feature-1");
+        let pr3 = make_test_pr(3, "other-1", "main");
+
+        let stacks = group_into_stacks(vec![pr1, pr2, pr3], "main");
+
+        assert_eq!(stacks.len(), 2);
+        // Larger stack first
+        assert_eq!(stacks[0].len(), 2);
+        assert_eq!(stacks[1].len(), 1);
+    }
+
+    #[test]
+    fn test_group_into_stacks_empty() {
+        let stacks = group_into_stacks(vec![], "main");
+        assert!(stacks.is_empty());
+    }
+
+    // === sort_stack tests ===
+
+    #[test]
+    fn test_sort_stack_linear() {
+        let pr1 = make_test_pr(1, "feature-1", "main");
+        let pr2 = make_test_pr(2, "feature-2", "feature-1");
+        let pr3 = make_test_pr(3, "feature-3", "feature-2");
+
+        // Give them in wrong order
+        let prs = vec![pr3, pr1, pr2];
+        let sorted = sort_stack(prs, "main");
+
+        assert_eq!(sorted.len(), 3);
+        assert_eq!(sorted[0].number(), 1); // base: main
+        assert_eq!(sorted[1].number(), 2); // base: feature-1
+        assert_eq!(sorted[2].number(), 3); // base: feature-2
+    }
+
+    #[test]
+    fn test_sort_stack_single() {
+        let pr = make_test_pr(1, "feature", "main");
+
+        let sorted = sort_stack(vec![pr], "main");
+        assert_eq!(sorted.len(), 1);
+        assert_eq!(sorted[0].number(), 1);
+    }
+
+    #[test]
+    fn test_sort_stack_empty() {
+        let sorted = sort_stack(vec![], "main");
+        assert!(sorted.is_empty());
+    }
+
+    // === API tests with mocks ===
 
     #[tokio::test]
     #[serial]
@@ -499,76 +760,9 @@ mod tests {
         mock.assert_async().await;
     }
 
-    #[test]
-    fn test_sort_stack_linear() {
-        let pr1 = PullRequest::new_for_test(
-            1,
-            "feature-1",
-            "main",
-            "PR 1",
-            PullRequestStatus::Open,
-            false,
-            None,
-            vec![],
-        );
-        let pr2 = PullRequest::new_for_test(
-            2,
-            "feature-2",
-            "feature-1",
-            "PR 2",
-            PullRequestStatus::Open,
-            false,
-            None,
-            vec![],
-        );
-        let pr3 = PullRequest::new_for_test(
-            3,
-            "feature-3",
-            "feature-2",
-            "PR 3",
-            PullRequestStatus::Open,
-            false,
-            None,
-            vec![],
-        );
-
-        // Give them in wrong order
-        let prs = vec![pr3, pr1, pr2];
-        let sorted = sort_stack(prs, "main");
-
-        assert_eq!(sorted.len(), 3);
-        assert_eq!(sorted[0].number(), 1); // base: main
-        assert_eq!(sorted[1].number(), 2); // base: feature-1
-        assert_eq!(sorted[2].number(), 3); // base: feature-2
-    }
-
-    #[test]
-    fn test_sort_stack_single() {
-        let pr = PullRequest::new_for_test(
-            1,
-            "feature",
-            "main",
-            "PR 1",
-            PullRequestStatus::Open,
-            false,
-            None,
-            vec![],
-        );
-
-        let sorted = sort_stack(vec![pr], "main");
-        assert_eq!(sorted.len(), 1);
-        assert_eq!(sorted[0].number(), 1);
-    }
-
-    #[test]
-    fn test_sort_stack_empty() {
-        let sorted = sort_stack(vec![], "main");
-        assert!(sorted.is_empty());
-    }
-
     #[tokio::test]
     #[serial]
-    async fn test_fetch_all_open_prs() {
+    async fn test_fetch_all_open_prs_single_page() {
         let mut server = Server::new_async().await;
 
         let pr1 = make_pr_json(1, "feature-1", "main", "PR 1");
@@ -579,6 +773,7 @@ mod tests {
             .match_query(mockito::Matcher::AllOf(vec![
                 mockito::Matcher::UrlEncoded("state".into(), "open".into()),
                 mockito::Matcher::UrlEncoded("per_page".into(), "100".into()),
+                mockito::Matcher::UrlEncoded("page".into(), "1".into()),
             ]))
             .with_status(200)
             .with_header("content-type", "application/json")
@@ -593,6 +788,111 @@ mod tests {
 
         assert!(result.is_ok());
         assert_eq!(result.unwrap().len(), 2);
+
+        mock.assert_async().await;
+    }
+
+    #[tokio::test]
+    #[serial]
+    async fn test_fetch_all_open_prs_pagination() {
+        let mut server = Server::new_async().await;
+
+        // Generate 100 PRs for page 1 (triggers pagination)
+        let page1_prs: Vec<String> = (1..=100)
+            .map(|i| make_pr_json(i, &format!("feature-{}", i), "main", &format!("PR {}", i)))
+            .collect();
+        let page1_body = format!("[{}]", page1_prs.join(","));
+
+        // Page 2 has fewer than 100, indicating end
+        let pr101 = make_pr_json(101, "feature-101", "main", "PR 101");
+
+        let mock_page1 = server
+            .mock("GET", "/repos/owner/repo/pulls")
+            .match_query(mockito::Matcher::AllOf(vec![
+                mockito::Matcher::UrlEncoded("state".into(), "open".into()),
+                mockito::Matcher::UrlEncoded("per_page".into(), "100".into()),
+                mockito::Matcher::UrlEncoded("page".into(), "1".into()),
+            ]))
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body(page1_body)
+            .create_async()
+            .await;
+
+        let mock_page2 = server
+            .mock("GET", "/repos/owner/repo/pulls")
+            .match_query(mockito::Matcher::AllOf(vec![
+                mockito::Matcher::UrlEncoded("state".into(), "open".into()),
+                mockito::Matcher::UrlEncoded("per_page".into(), "100".into()),
+                mockito::Matcher::UrlEncoded("page".into(), "2".into()),
+            ]))
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body(format!("[{}]", pr101))
+            .create_async()
+            .await;
+
+        std::env::set_var("GITHUB_API_BASE", server.url());
+
+        let creds = Credentials::new("test-token");
+        let result = fetch_all_open_prs("owner/repo", &creds).await;
+
+        assert!(result.is_ok());
+        assert_eq!(result.unwrap().len(), 101);
+
+        mock_page1.assert_async().await;
+        mock_page2.assert_async().await;
+    }
+
+    #[tokio::test]
+    #[serial]
+    async fn test_discover_stack_batch_fetch() {
+        let mut server = Server::new_async().await;
+
+        // Create a 3-PR stack
+        let pr1 = make_pr_json(1, "feature-1", "main", "PR 1");
+        let pr2 = make_pr_json(2, "feature-2", "feature-1", "PR 2");
+        let pr3 = make_pr_json(3, "feature-3", "feature-2", "PR 3");
+
+        // Single batch fetch should be enough
+        let mock = server
+            .mock("GET", "/repos/owner/repo/pulls")
+            .match_query(mockito::Matcher::AllOf(vec![
+                mockito::Matcher::UrlEncoded("state".into(), "open".into()),
+                mockito::Matcher::UrlEncoded("per_page".into(), "100".into()),
+                mockito::Matcher::UrlEncoded("page".into(), "1".into()),
+            ]))
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body(format!("[{}, {}, {}]", pr1, pr2, pr3))
+            .expect(1) // Should only be called once!
+            .create_async()
+            .await;
+
+        std::env::set_var("GITHUB_API_BASE", server.url());
+
+        let creds = Credentials::new("test-token");
+
+        // Create starting PR
+        let starting_pr = PullRequest::new_for_test(
+            2,
+            "feature-2",
+            "feature-1",
+            "PR 2",
+            PullRequestStatus::Open,
+            false,
+            None,
+            vec![],
+        );
+
+        let result = discover_stack("owner/repo", starting_pr, "main", &creds).await;
+
+        assert!(result.is_ok());
+        let stack = result.unwrap();
+        assert_eq!(stack.len(), 3);
+        assert_eq!(stack[0].number(), 1); // bottom
+        assert_eq!(stack[1].number(), 2);
+        assert_eq!(stack[2].number(), 3); // top
 
         mock.assert_async().await;
     }


### PR DESCRIPTION
## Summary

Optimize stack discovery by replacing sequential API calls with a batch-fetch strategy. This dramatically improves performance for the `gh-stack log` and `gh-stack status` commands.

## Problem

The previous implementation made **O(N+M) sequential API calls** to walk the PR chain:
- Walk UP: `fetch_pr_by_head()` for each ancestor
- Walk DOWN: `fetch_prs_by_base()` for each descendant

For a 6-PR stack, this meant ~12 HTTP requests with network latency (~100-500ms each), resulting in **6+ seconds** of wait time.

## Solution

**Batch fetch all open PRs first, then walk the chain in-memory:**

1. Single paginated API call to fetch all open PRs
2. Build in-memory `PrIndex` for fast head/base lookups
3. Walk the chain without any additional API calls

## Changes

**Modified: `src/api/stack.rs`**

- Add pagination to `fetch_all_open_prs()` - supports up to 1000 PRs (10 pages)
- Add `PrIndex` struct for O(1) lookup by head or base branch
- Refactor `discover_stack()` to use batch fetch + in-memory walk
- Extract `discover_stack_from_index()` for pure in-memory operation
- Extract `group_into_stacks()` for code reuse

## Performance

| Scenario | Before | After |
|----------|--------|-------|
| 6-PR stack | ~12 API calls (~6s) | 1-2 API calls (~2s) |
| Any stack size | O(N) calls | O(1) calls |

## Enterprise Support

- Pagination handles repositories with 100+ open PRs
- Capped at 1000 PRs (10 pages) for safety and to avoid runaway requests

## Tests

11 new tests added:
- `test_pr_index_get_by_head` / `get_by_base`
- `test_discover_stack_from_index_*` (4 scenarios)
- `test_group_into_stacks_*` (3 scenarios)
- `test_fetch_all_open_prs_pagination`
- `test_discover_stack_batch_fetch`


<!---GHSTACKOPEN-->
### Stacked PR Chain: smart-log
| PR | Title | Merges Into |
|:--:|:------|:-----------:|
|#35|feat: add stack discovery API|-|
|#36|feat: add rate limit retry logic|#35|
|#37|feat: add identifier detection and prompts|#36|
|#38|feat: add gh CLI helpers|#37|
|#39|feat: make log and status identifier optional with branch inference|#38|
|#40|docs: update log and status documentation for smart defaults|#39|
|#41|👉perf: optimize stack discovery with batch fetch|#40|
|#42|perf: parallelize status check fetches|#41|
<!---GHSTACKCLOSE-->


